### PR TITLE
Readonly mode for Shipment form

### DIFF
--- a/src/midgard/components/DatePicker/DatePicker.js
+++ b/src/midgard/components/DatePicker/DatePicker.js
@@ -19,6 +19,7 @@ export default function DatePickerComponent({
   label,
   hasTime,
   helpText,
+  disabled
 }) {
   return (
     <div style={{ display: "flex", alignItems: "center" }}>
@@ -30,6 +31,7 @@ export default function DatePickerComponent({
             ampm={false}
             fullWidth
             margin="normal"
+            disabled={disabled}
             label={label}
             value={selectedDate}
             onChange={handleDateChange}
@@ -44,6 +46,7 @@ export default function DatePickerComponent({
             variant="inline"
             format="MM/dd/yyyy"
             margin="normal"
+            disabled={disabled}
             id="date-picker-inline"
             label={label}
             value={selectedDate}

--- a/src/midgard/components/InlineEditor/InlineEditor.js
+++ b/src/midgard/components/InlineEditor/InlineEditor.js
@@ -107,7 +107,7 @@ export function InlineEditor({id, tag, value, placeholder, onChange}) {
             <Typography className={classes.typography} variant={tag}>{value || placeholder}</Typography>
           </Grid>
           <Grid item="true">
-            <EditIcon className={classes.editIcon} color="action" onClick={() => setEditing(true)}></EditIcon>
+            <EditIcon className={classes.editIcon} color="default" onClick={() => setEditing(true)}></EditIcon>
           </Grid>
         </Grid>
       )}

--- a/src/midgard/components/MapComponent/MapComponent.js
+++ b/src/midgard/components/MapComponent/MapComponent.js
@@ -39,10 +39,10 @@ const RenderedMap = withScriptjs(
     <GoogleMap defaultZoom={5} defaultCenter={props.center}>
       {props.isMarkerShown &&
         props.markers &&
-        props.markers.map((mark, indx) =>
+        props.markers.map((mark, index) =>
           mark.label ? (
             <MarkerWithLabel
-              key={`${mark.lat},${mark.lng}`}
+              key={`marker${index}:${mark.lat},${mark.lng}`}
               position={{ lat: mark.lat, lng: mark.lng }}
               labelAnchor={new google.maps.Point(0, 0)}
               icon={mark.icon}
@@ -60,7 +60,7 @@ const RenderedMap = withScriptjs(
           ) : (
             <Marker
               draggable={mark.draggable}
-              key={mark.lat && mark.lng ? `${mark.lat},${mark.lng}` : `${indx}`}
+              key={mark.lat && mark.lng ? `marker${index}:${mark.lat},${mark.lng}` : `marker${index}`}
               position={
                 mark.lat && mark.lng
                   ? { lat: mark.lat, lng: mark.lng }

--- a/src/midgard/components/PermissionsTable/PermissionsTable.js
+++ b/src/midgard/components/PermissionsTable/PermissionsTable.js
@@ -42,11 +42,11 @@ const StyledContainer = withStyles((theme) => ({
 }))(Box);
 
 export function PermissionsTable({columns, rows}) {
-  const header = columns.map(col => <StyledTableHeadCell key={col.prop}>{col.label}</StyledTableHeadCell>);
+  const header = columns.map((col, colIndex) => <StyledTableHeadCell key={`tableCol${colIndex}:${col.prop}`}>{col.label}</StyledTableHeadCell>);
   const content = rows.map((row, rowIndex) => (
-    <StyledTableRow key={"table-row-" + rowIndex}>
+    <StyledTableRow key={`tableRow${rowIndex}`}>
       {columns.map((col, colIndex) => (
-        <TableCell key={"table-cell-" + rowIndex + '-' + colIndex}>
+        <TableCell key={`tableCell${rowIndex}:${colIndex}`}>
           {col.template(row)}
         </TableCell>
       ))}

--- a/src/midgard/components/Slider/RangeSlider.js
+++ b/src/midgard/components/Slider/RangeSlider.js
@@ -52,6 +52,7 @@ export default function RangeSlider({
   rangeText,
   max,
   min,
+  disabled,
   handleSliderChange,
   marks,
   orientation,
@@ -70,6 +71,7 @@ export default function RangeSlider({
         aria-labelledby="range-slider"
         valueLabelDisplay="auto"
         // ValueLabelComponent={ValueLabelComponent}
+        disabled={disabled}
         marks={marks}
         onChange={handleSliderChange}
       />

--- a/src/midgard/components/Table/Table.js
+++ b/src/midgard/components/Table/Table.js
@@ -9,6 +9,7 @@ import TableHead from "@material-ui/core/TableHead";
 import TablePagination from "@material-ui/core/TablePagination";
 import TableRow from "@material-ui/core/TableRow";
 import EditIcon from "@material-ui/icons/Edit";
+import ViewIcon from "@material-ui/icons/RemoveRedEye";
 import DeleteIcon from "@material-ui/icons/Delete";
 import IconButton from "@material-ui/core/IconButton";
 import SearchInput from "../SearchComponent/SearchInput";
@@ -151,7 +152,9 @@ export default function DataTable({ ...props }) {
                               >
                                 {actionItemType === "edit" ? (
                                   <EditIcon />
-                                ) : actionItemType === "unlink" ? (
+                                ) : actionItemType === "view" ? (
+                                  <ViewIcon />
+                                )  : actionItemType === "unlink" ? (
                                   <LinkOffIcon />
                                 ) : (
                                   <DeleteIcon />

--- a/src/midgard/components/Table/Table.js
+++ b/src/midgard/components/Table/Table.js
@@ -99,18 +99,18 @@ export default function DataTable({ ...props }) {
           <TableHead>
             <StyledTableRow>
               {actionsColumns &&
-                actionsColumns.map((action, id) => (
+                actionsColumns.map((action, index) => (
                   <StyledTableHead
-                    key={action.id}
+                    key={`actionCol${index}:${action.id}`}
                     align={"left"}
                     style={{ minWidth: 50 }}
                   >
                     {action.label}
                   </StyledTableHead>
                 ))}
-              {columns.map((column) => (
+              {columns.map((column, index) => (
                 <StyledTableHead
-                  key={column.id}
+                  key={`col${index}:${column.id}`}
                   align={column.align}
                   style={{
                     minWidth: column.minWidth,
@@ -126,20 +126,20 @@ export default function DataTable({ ...props }) {
             {rows.length > 0 &&
               rows
                 // .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map((row, idx) => {
+                .map((row, rowIndex) => {
                   return (
                     <StyledTableRow
                       hover
                       role="checkbox"
                       tabIndex={-1}
-                      key={`tableRow${idx}`}
+                      key={`tableRow${rowIndex}`}
                     >
                       {actionsColumns &&
-                        actionsColumns.map((action, id) => {
+                        actionsColumns.map((action, colIndex) => {
                           const actionItemType = action.type;
                           return (
                             <StyledTableHead
-                              key={action.id}
+                              key={`tableRow${rowIndex}:${colIndex}`}
                               align={"left"}
                               style={{ minWidth: 50, width: 50 }}
                             >
@@ -160,11 +160,11 @@ export default function DataTable({ ...props }) {
                             </StyledTableHead>
                           );
                         })}
-                      {columns.map((column) => {
+                      {columns.map((column, colIndex) => {
                         const value = row[column.id] || "-";
                         return (
                           <TableCell
-                            key={column.id}
+                            key={`col${colIndex}:${column.id}`}
                             align={column.align}
                             style={{
                               minWidth: column.minWidth,

--- a/src/midgard/layout/NavBar/NavBar.js
+++ b/src/midgard/layout/NavBar/NavBar.js
@@ -87,21 +87,20 @@ function NavBar({ navHidden, setNavHidden, location, history, userData }) {
     <div>
       <div className={classes.toolbar} />
       <List>
-        {navItems.map((items, index) => (
-          <React.Fragment key={`${items.id}${index}`}>
+        {navItems.map((item, index) => (
+          <React.Fragment key={`navItem${index}${item.id}`}>
             <NavLink
-              to={items.link}
+              to={item.link}
               activeClassName={classes.active}
-              title={items.name}
+              title={item.name}
               className={classes.navLink}
             >
               <ListItem
                 button
                 className={classes.navItems}
-                key={items.id}
-                onClick={(event) => handleListItemClick(event, index, items)}
+                onClick={(event) => handleListItemClick(event, index, item)}
               >
-                <ListItemText primary={items.name} />
+                <ListItemText primary={item.name} />
               </ListItem>
             </NavLink>
             <Divider />

--- a/src/midgard/pages/Custodians/forms/AddCustodians.js
+++ b/src/midgard/pages/Custodians/forms/AddCustodians.js
@@ -335,7 +335,7 @@ function AddCustodians({
                       .sort(compareSort("name"))
                       .map((item, index) => (
                         <MenuItem
-                          key={`${item.id}${item.name}`}
+                          key={`custodianType${index}:${item.id}`}
                           value={item.url}
                         >
                           {item.name}
@@ -551,8 +551,8 @@ function AddCustodians({
                       }
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {COUNTRY_CHOICES.sort().map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {COUNTRY_CHOICES.sort().map((value, index) => (
+                        <MenuItem key={`custodianCountry${index}${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}
@@ -591,8 +591,8 @@ function AddCustodians({
                       }
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {STATE_CHOICES.sort().map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {STATE_CHOICES.sort().map((value, index) => (
+                        <MenuItem key={`custodianState${index}${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}

--- a/src/midgard/pages/Items/Items.js
+++ b/src/midgard/pages/Items/Items.js
@@ -124,7 +124,7 @@ function Items({
       data: item,
     });
   };
-  const deletItem = (item) => {
+  const deleteItem = (item) => {
     setDeleteItemId(item.id);
     setConfirmModal(true);
   };
@@ -157,7 +157,7 @@ function Items({
       dashboardHeading={"Items"}
       addButtonHeading={"Add Item"}
       editAction={editItem}
-      deleteAction={deletItem}
+      deleteAction={deleteItem}
       columns={itemColumns}
       redirectTo={redirectTo}
       rows={filteredRows}

--- a/src/midgard/pages/Items/forms/AddItems.js
+++ b/src/midgard/pages/Items/forms/AddItems.js
@@ -344,7 +344,7 @@ function AddItems({
                       .sort(compareSort("name"))
                       .map((item, index) => (
                         <MenuItem
-                          key={`${item.id}${item.name}`}
+                          key={`itemType${index}:${item.id}`}
                           value={item.url}
                         >
                           {item.name}
@@ -829,7 +829,7 @@ function AddItems({
                       .sort(compareSort("name"))
                       .map((item, index) => (
                         <MenuItem
-                          key={`${item.id}${item.name}`}
+                          key={`weightUnit${index}:${item.id}`}
                           value={item.url}
                         >
                           {item.name}

--- a/src/midgard/pages/Profile/Profile.js
+++ b/src/midgard/pages/Profile/Profile.js
@@ -105,7 +105,7 @@ function Profile({ dispatch, history, location }) {
           <Grid container className={classes.root} spacing={2}>
             {dashboardItems.map((items, index) => {
               return (
-                <Grid item md={3} xs={6} key={`${items.name}${index}`}>
+                <Grid item md={3} xs={6} key={`dashboardItem${index}:${items.name}`}>
                   <div className={classes.dashboardHeaderItems}>
                     <Typography variant={"h4"}>{items.number}</Typography>
                     <Typography variant={"subtitle2"}>{items.name}</Typography>

--- a/src/midgard/pages/SensorsGateway/forms/AddGateway.js
+++ b/src/midgard/pages/SensorsGateway/forms/AddGateway.js
@@ -280,7 +280,7 @@ function AddGateway({
                       {gatewayTypeList &&
                         gatewayTypeList.map((item, index) => (
                           <MenuItem
-                            key={`${item.id}${item.name}`}
+                            key={`gatewayType${index}:${item.id}`}
                             value={item.url}
                           >
                             {item.name}

--- a/src/midgard/pages/SensorsGateway/forms/AddSensors.js
+++ b/src/midgard/pages/SensorsGateway/forms/AddSensors.js
@@ -399,7 +399,7 @@ function AddSensor({
                       {sensorTypeList &&
                         sensorTypeList.map((item, index) => (
                           <MenuItem
-                            key={`${item.id}${item.name}`}
+                            key={`sensorType${index}:${item.id}`}
                             value={item.url}
                           >
                             {item.name}

--- a/src/midgard/pages/Shipment/AlertInfo.js
+++ b/src/midgard/pages/Shipment/AlertInfo.js
@@ -102,7 +102,7 @@ function AlertInfo(props) {
         shipmentAlerts.data.map((alert, index) => {
           return (
             <Alert
-              key={`alert${index}`}
+              key={`shipmentAlert${index}:${alert.shipment}`}
               variant="filled"
               severity={alert.severity}
               onClose={(e) => handleClose(e, index)}

--- a/src/midgard/pages/Shipment/Shipment.js
+++ b/src/midgard/pages/Shipment/Shipment.js
@@ -301,7 +301,7 @@ function Shipment(props) {
               <IconButton
                 className={classes.menuButton}
                 onClick={() => setTileView(!tileView)}
-                color="action"
+                color="default"
                 aria-label="menu"
               >
                 {!tileView ? <ViewCompactIcon /> : <ViewComfyIcon />}
@@ -327,7 +327,7 @@ function Shipment(props) {
               <IconButton
                 className={classes.menuButton}
                 onClick={() => setTileView(!tileView)}
-                color="action"
+                color="default"
                 aria-label="menu"
               >
                 {!tileView ? <ViewCompactIcon /> : <ViewComfyIcon />}

--- a/src/midgard/pages/Shipment/ShipmentConstants.js
+++ b/src/midgard/pages/Shipment/ShipmentConstants.js
@@ -33,10 +33,11 @@ export const SHIPMENT_COLUMNS = [
       if (row && row.flag_list && value && value !== "-") {
         return (
           <React.Fragment>
-            {row.flag_list.map((obj, idx) => {
+            {row.flag_list.map((obj, index) => {
               if (obj.name.toLowerCase().includes("temp")) {
                 return (
                   <TempIcon
+                    key={`iconTemp${index}`}
                     color={
                       obj.type.toLowerCase() === "warning"
                         ? "#ff9800"
@@ -47,6 +48,7 @@ export const SHIPMENT_COLUMNS = [
               } else if (obj.name.toLowerCase().includes("humid")) {
                 return (
                   <HumidIcon
+                    key={`iconHumid${index}`}
                     color={
                       obj.type.toLowerCase() === "warning"
                         ? "#ff9800"
@@ -57,6 +59,7 @@ export const SHIPMENT_COLUMNS = [
               } else if (obj.name.toLowerCase().includes("delay")) {
                 return (
                   <DelayIcon
+                    key={`iconDelay${index}`}
                     color={
                       obj.type.toLowerCase() === "warning"
                         ? "#ff9800"
@@ -67,6 +70,7 @@ export const SHIPMENT_COLUMNS = [
               } else if (obj.name.toLowerCase().includes("recall")) {
                 return (
                   <RecallIcon
+                    key={`iconRecall${index}`}
                     color={
                       obj.type.toLowerCase() === "warning"
                         ? "#ff9800"

--- a/src/midgard/pages/Shipment/components/EnvironmentalLimitsInfo.js
+++ b/src/midgard/pages/Shipment/components/EnvironmentalLimitsInfo.js
@@ -87,6 +87,7 @@ function EnvironmentalLimitsInfo(props) {
     handleCancel,
     location,
     shipmentOptions,
+    viewOnly
   } = props;
   const theme = useTheme();
   const classes = useStyles();
@@ -195,7 +196,7 @@ function EnvironmentalLimitsInfo(props) {
         <Grid item xs={12} md={6} sm={6}>
           <Card variant="outlined">
             <Typography className={classes.boxHeading} variant="body2">
-              Temperature Settings
+              Temperature settings
             </Typography>
             <CardContent>
               <Grid container spacing={2}>
@@ -209,6 +210,7 @@ function EnvironmentalLimitsInfo(props) {
                     name="max_temp_val"
                     autoComplete="max_temp_val"
                     value={max_temp_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["max_excursion_temp"] &&
                       shipmentMetaData["max_excursion_temp"].help_text && {
@@ -233,10 +235,11 @@ function EnvironmentalLimitsInfo(props) {
                     margin="normal"
                     fullWidth
                     id="high_temp_val"
-                    label="Warning High"
+                    label="Warning high"
                     name="high_temp_val"
                     autoComplete="high_temp_val"
                     value={high_temp_val}
+                    disabled={viewOnly}
                     // {...last_known_location.bind}
                     InputProps={
                       shipmentMetaData["max_warning_temp"] &&
@@ -260,10 +263,11 @@ function EnvironmentalLimitsInfo(props) {
                     margin="normal"
                     fullWidth
                     id="low_temp_val"
-                    label="Warning Low"
+                    label="Warning low"
                     name="low_temp_val"
                     autoComplete="low_temp_val"
                     value={low_temp_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["min_warning_temp"] &&
                       shipmentMetaData["min_warning_temp"].help_text && {
@@ -291,6 +295,7 @@ function EnvironmentalLimitsInfo(props) {
                     name="min_temp_val"
                     autoComplete="min_temp_val"
                     value={min_temp_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["min_excursion_temp"] &&
                       shipmentMetaData["min_excursion_temp"].help_text && {
@@ -314,6 +319,7 @@ function EnvironmentalLimitsInfo(props) {
                 <Grid item xs={6} className={classes.slider}>
                   <RangeSlider
                     value={minMaxTempValue}
+                    disabled={viewOnly}
                     orientation={"vertical"}
                     handleSliderChange={handleTempMinMaxChange}
                     rangeText={""}
@@ -339,7 +345,7 @@ function EnvironmentalLimitsInfo(props) {
         <Grid item xs={12} md={6} sm={6}>
           <Card variant="outlined">
             <Typography className={classes.boxHeading} variant="body2">
-              Humidity Settings(%)
+              Humidity settings (%)
             </Typography>
             <CardContent>
               <Grid container spacing={4}>
@@ -353,6 +359,7 @@ function EnvironmentalLimitsInfo(props) {
                     name="max_humid_val"
                     autoComplete="max_humid_val"
                     value={max_humid_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["max_excursion_humidity"] &&
                       shipmentMetaData["max_excursion_humidity"].help_text && {
@@ -377,10 +384,11 @@ function EnvironmentalLimitsInfo(props) {
                     margin="normal"
                     fullWidth
                     id="high_humid_val"
-                    label="Warning High"
+                    label="Warning high"
                     name="high_humid_val"
                     autoComplete="high_humid_val"
                     value={high_humid_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["max_warning_humidity"] &&
                       shipmentMetaData["max_warning_humidity"].help_text && {
@@ -406,10 +414,11 @@ function EnvironmentalLimitsInfo(props) {
                     margin="normal"
                     fullWidth
                     id="low_humid_val"
-                    label="Warning Low"
+                    label="Warning low"
                     name="low_humid_val"
                     autoComplete="low_humid_val"
                     value={low_humid_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["min_warning_humidity"] &&
                       shipmentMetaData["min_warning_humidity"].help_text && {
@@ -439,6 +448,7 @@ function EnvironmentalLimitsInfo(props) {
                     name="min_humid_val"
                     autoComplete="min_humid_val"
                     value={min_humid_val}
+                    disabled={viewOnly}
                     InputProps={
                       shipmentMetaData["min_excursion_humidity"] &&
                       shipmentMetaData["min_excursion_humidity"].help_text && {
@@ -462,6 +472,7 @@ function EnvironmentalLimitsInfo(props) {
                 <Grid item xs={6} className={classes.slider}>
                   <RangeSlider
                     value={minMaxHumidValue}
+                    disabled={viewOnly}
                     orientation={"vertical"}
                     handleSliderChange={handleHumidMinMaxChange}
                     rangeText={""}
@@ -492,21 +503,36 @@ function EnvironmentalLimitsInfo(props) {
         className={classes.buttonContainer}
       >
         <Grid item xs={6} sm={4}>
-          <div className={classes.loadingWrapper}>
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              color="primary"
-              className={classes.submit}
-              disabled={loading}
-            >
-              {`Save`}
-            </Button>
-            {loading && (
-              <CircularProgress size={24} className={classes.buttonProgress} />
-            )}
-          </div>
+          {!viewOnly && (
+            <div className={classes.loadingWrapper}>
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                disabled={viewOnly}
+                className={classes.submit}
+                disabled={loading}
+              >
+                Save
+              </Button>
+              {loading && (
+                <CircularProgress size={24} className={classes.buttonProgress} />
+              )}
+            </div>
+          )}
+        </Grid>
+        <Grid item xs={6} sm={4}>
+          <Button
+            type="button"
+            fullWidth
+            variant="contained"
+            color="primary"
+            className={classes.submit}
+            onClick={handleCancel}
+          >
+            Done
+          </Button>
         </Grid>
       </Grid>
     </form>

--- a/src/midgard/pages/Shipment/components/ItemInfo.js
+++ b/src/midgard/pages/Shipment/components/ItemInfo.js
@@ -70,9 +70,11 @@ function ItemsInfo(props) {
     redirectTo,
     loading,
     handleNext,
+    handleCancel,
     shipmentFormData,
     dispatch,
     unitsOfMeasure,
+    viewOnly
   } = props;
   const [itemIds, setItemIds] = useState(
     (shipmentFormData && shipmentFormData.items) || []
@@ -122,6 +124,7 @@ function ItemsInfo(props) {
       )
     );
   };
+  console.log(props)
 
   return (
     <Box mb={5} mt={3}>
@@ -133,6 +136,7 @@ function ItemsInfo(props) {
                 <Autocomplete
                   multiple
                   id="tags-outlined"
+                  disabled={viewOnly}
                   options={
                     (itemData && itemData.sort(compareSort("name"))) || []
                   }
@@ -158,9 +162,10 @@ function ItemsInfo(props) {
                   renderInput={(params) => (
                     <TextField
                       {...params}
+                      disabled={viewOnly}
                       variant="outlined"
-                      label="Select Items To Be Associated"
-                      placeholder="Select an Items"
+                      label="Select items to be associated"
+                      placeholder="Select an item"
                     />
                   )}
                 />
@@ -190,26 +195,38 @@ function ItemsInfo(props) {
         </Box>
         <Grid container spacing={3} className={classes.buttonContainer}>
           <Grid item xs={6} sm={2}>
-            <div className={classes.loadingWrapper}>
+            {viewOnly ? (
               <Button
-                type="submit"
+                type="button"
                 fullWidth
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                disabled={loading || submitDisabled()}
+                onClick={handleCancel}
               >
-                {`Save`}
+                Done
               </Button>
-              {loading && (
-                <CircularProgress
-                  size={24}
-                  className={classes.buttonProgress}
-                />
-              )}
-            </div>
+            ) : (
+              <div className={classes.loadingWrapper}>
+                <Button
+                  type="submit"
+                  fullWidth
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  disabled={loading || submitDisabled()}
+                >
+                  Save
+                </Button>
+                {loading && (
+                  <CircularProgress
+                    size={24}
+                    className={classes.buttonProgress}
+                  />
+                )}
+              </div>
+            )}
           </Grid>
-
           <Grid item xs={12} sm={4}>
             <Button
               variant="contained"
@@ -218,7 +235,7 @@ function ItemsInfo(props) {
               onClick={handleNext}
               className={classes.submit}
             >
-              {`Next: Add Custodians`}
+              {`Next: Custodians`}
             </Button>
           </Grid>
         </Grid>

--- a/src/midgard/pages/Shipment/components/Sensors&GatewayInfo.js
+++ b/src/midgard/pages/Shipment/components/Sensors&GatewayInfo.js
@@ -75,10 +75,12 @@ function SensorsGatewayInfo(props) {
     redirectTo,
     loading,
     handleNext,
+    handleCancel,
     shipmentFormData,
     dispatch,
     sensorData,
     sensorTypeList,
+    viewOnly
   } = props;
   const [gatewayId, setGatewayId] = useState(
     (shipmentFormData &&
@@ -146,6 +148,7 @@ function SensorsGatewayInfo(props) {
               <Grid item xs={12}>
                 <Autocomplete
                   id="combo-box-demo"
+                  disabled={viewOnly}
                   options={
                     (gatewayData && gatewayData.sort(compareSort("name"))) || []
                   }
@@ -160,6 +163,7 @@ function SensorsGatewayInfo(props) {
                   renderInput={(params) => (
                     <TextField
                       {...params}
+                      disabled={viewOnly}
                       label="Associate to Gateway"
                       variant="outlined"
                       placeholder="Select a Gateway"
@@ -206,24 +210,37 @@ function SensorsGatewayInfo(props) {
         </Box>
         <Grid container spacing={3} className={classes.buttonContainer}>
           <Grid item xs={6} sm={2}>
-            <div className={classes.loadingWrapper}>
+            {viewOnly ? (
               <Button
-                type="submit"
+                type="button"
                 fullWidth
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                disabled={loading || submitDisabled()}
+                onClick={handleCancel}
               >
-                {`Save`}
+                Done
               </Button>
-              {loading && (
-                <CircularProgress
-                  size={24}
-                  className={classes.buttonProgress}
-                />
-              )}
-            </div>
+            ) : (
+              <div className={classes.loadingWrapper}>
+                <Button
+                  type="submit"
+                  fullWidth
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  disabled={loading || submitDisabled()}
+                >
+                  Save
+                </Button>
+                {loading && (
+                  <CircularProgress
+                    size={24}
+                    className={classes.buttonProgress}
+                  />
+                )}
+              </div>
+            )}
           </Grid>
 
           <Grid item xs={12} sm={4}>
@@ -234,7 +251,7 @@ function SensorsGatewayInfo(props) {
               onClick={handleNext}
               className={classes.submit}
             >
-              {`Next: Add Environmental Limits`}
+              {`Next: Environmental Limits`}
             </Button>
           </Grid>
         </Grid>

--- a/src/midgard/pages/Shipment/components/ShipmentFilterAndSort.js
+++ b/src/midgard/pages/Shipment/components/ShipmentFilterAndSort.js
@@ -175,16 +175,16 @@ const SortFilter = (props) => {
         <div className={classes.popper}>
           <List component="ul">
             <ListItem
-              selected={sortValue === "dateAsc"}
               button
-              onClick={() => handleSort("dateAsc")}
+              selected={sortValue === "dateDesc"}
+              onClick={() => handleSort("dateDesc")}
             >
               Most recent
             </ListItem>
             <ListItem
               button
-              selected={sortValue === "dateDesc"}
-              onClick={() => handleSort("dateDesc")}
+              selected={sortValue === "dateAsc"}
+              onClick={() => handleSort("dateAsc")}
             >
               Least recent
             </ListItem>

--- a/src/midgard/pages/Shipment/components/ShipmentInfo.js
+++ b/src/midgard/pages/Shipment/components/ShipmentInfo.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { connect } from "react-redux";
 import moment from "moment";
 import Button from "@material-ui/core/Button";
@@ -38,6 +38,8 @@ import {
 import ItemsInfo from "./ItemInfo";
 import ShipmentRouteInfo from "./ShipmentRouteInfo";
 import CustomizedTooltips from "../../../components/ToolTip/ToolTip";
+import { checkForGlobalAdmin } from "midgard/utils/utilMethods";
+import { UserContext } from "midgard/context/User.context";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -97,6 +99,7 @@ function ShipmentInfo(props) {
     custodyData,
     unitsOfMeasure,
     shipmentOptions,
+    viewOnly
   } = props;
   const theme = useTheme();
   let isDesktop = useMediaQuery(theme.breakpoints.up("sm"));
@@ -106,6 +109,7 @@ function ShipmentInfo(props) {
   const shipment_name = useInput((editData && editData.name) || "", {
     required: true,
   });
+  
   const lading_bill = useInput((editData && editData.bol_order_id) || "");
   const load_no = useInput("");
   const shipment_status = useInput((editData && editData.status) || "");
@@ -324,9 +328,10 @@ function ShipmentInfo(props) {
                       fullWidth
                       required
                       id="shipment_name"
-                      label="Shipment Name"
+                      label="Shipment name"
                       name="shipment_name"
                       autoComplete="shipment_name"
+                      disabled={viewOnly}
                       error={
                         formError.shipment_name && formError.shipment_name.error
                       }
@@ -360,9 +365,10 @@ function ShipmentInfo(props) {
                       margin="normal"
                       fullWidth
                       id="lading_bill"
-                      label="Bill of Lading"
+                      label="Bill of lading"
                       name="lading_bill"
                       autoComplete="lading_bill"
+                      disabled={viewOnly}
                       {...lading_bill.bind}
                       InputProps={
                         fieldsMetadata["lading_bill"].help_text && {
@@ -390,7 +396,8 @@ function ShipmentInfo(props) {
                       required
                       id="mode_type"
                       select
-                      label="Mode Type"
+                      label="Mode type"
+                      disabled={viewOnly}
                       {...mode_type.bind}
                       InputProps={
                         fieldsMetadata["mode_type"].help_text && {
@@ -427,9 +434,10 @@ function ShipmentInfo(props) {
                       multiline
                       rows={6}
                       id="route_desc"
-                      label="Route Description"
+                      label="Route description"
                       name="route_desc"
                       autoComplete="route_desc"
+                      disabled={viewOnly}
                       {...route_desc.bind}
                       InputProps={
                         fieldsMetadata["route_desc"].help_text && {
@@ -456,7 +464,8 @@ function ShipmentInfo(props) {
                       required
                       id="uom_temp"
                       select
-                      label="Units of Measure Temperature"
+                      label="Unit of measure temperature"
+                      disabled={viewOnly}
                       value={uom_temp}
                       onChange={(e) => setUomTemp(e.target.value)}
                       InputProps={
@@ -504,7 +513,8 @@ function ShipmentInfo(props) {
                       id="shipment_status"
                       name="shipment_status"
                       select
-                      label="Shipment Status"
+                      label="Shipment status"
+                      disabled={viewOnly}
                       {...shipment_status.bind}
                       InputProps={
                         fieldsMetadata["shipment_status"].help_text && {
@@ -536,10 +546,11 @@ function ShipmentInfo(props) {
 
                   <Grid item xs={12}>
                     <DatePickerComponent
-                      label={"Scheduled Departure"}
+                      label={"Scheduled departure"}
                       selectedDate={scheduled_departure}
                       hasTime={true}
                       handleDateChange={handleDepartureDateChange}
+                      disabled={viewOnly}
                       helpText={
                         fieldsMetadata["scheduled_departure"] &&
                         fieldsMetadata["scheduled_departure"].help_text
@@ -550,10 +561,11 @@ function ShipmentInfo(props) {
                   </Grid>
                   <Grid item xs={12}>
                     <DatePickerComponent
-                      label={"Scheduled Arrival"}
+                      label={"Scheduled arrival"}
                       selectedDate={scheduled_arrival}
                       hasTime={true}
                       handleDateChange={handleScheduledDateChange}
+                      disabled={viewOnly}
                       helpText={
                         fieldsMetadata["scheduled_arrival"] &&
                         fieldsMetadata["scheduled_arrival"].help_text
@@ -567,6 +579,7 @@ function ShipmentInfo(props) {
                       <Autocomplete
                         multiple
                         id="tags-outlined"
+                        disabled={viewOnly}
                         options={shipmentFlag || []}
                         getOptionLabel={(option) => {
                           if (option) return `${option.name} (${option.type})`;
@@ -598,9 +611,11 @@ function ShipmentInfo(props) {
                           <TextField
                             {...params}
                             variant="outlined"
-                            label="Violation/Warnings"
+                            label="Violations/Warnings"
                             placeholder="Select"
+                            disabled={viewOnly}
                             margin="normal"
+                            disabled={viewOnly}
                           />
                         )}
                       />
@@ -620,8 +635,9 @@ function ShipmentInfo(props) {
                       required
                       id="uom_distance"
                       select
-                      label="Units of Measure Distance"
+                      label="Unit of measure distance"
                       value={uom_distance}
+                      disabled={viewOnly}
                       onChange={(e) => setUomDistance(e.target.value)}
                       InputProps={
                         fieldsMetadata["uom_distance"].help_text && {
@@ -666,8 +682,9 @@ function ShipmentInfo(props) {
                       required
                       id="uom_weight"
                       select
-                      label="Units of Measure Mass/Weight"
+                      label="Unit of measure mass/weight"
                       value={uom_weight}
+                      disabled={viewOnly}
                       onChange={(e) => setUomWeight(e.target.value)}
                       InputProps={
                         fieldsMetadata["uom_weight"].help_text && {
@@ -713,24 +730,37 @@ function ShipmentInfo(props) {
           </Box>
           <Grid container spacing={3} className={classes.buttonContainer}>
             <Grid item xs={6} sm={2}>
-              <div className={classes.loadingWrapper}>
+              {viewOnly ? (
                 <Button
-                  type="submit"
+                  type="button"
                   fullWidth
                   variant="contained"
                   color="primary"
                   className={classes.submit}
-                  disabled={loading || submitDisabled()}
+                  onClick={handleCancel}
                 >
-                  {`Save`}
+                  Done
                 </Button>
-                {loading && (
-                  <CircularProgress
-                    size={24}
-                    className={classes.buttonProgress}
-                  />
-                )}
-              </div>
+              ) : (
+                <div className={classes.loadingWrapper}>
+                  <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    className={classes.submit}
+                    disabled={loading || submitDisabled()}
+                  >
+                    Save
+                  </Button>
+                  {loading && (
+                    <CircularProgress
+                      size={24}
+                      className={classes.buttonProgress}
+                    />
+                  )}
+                </div>
+              )}
             </Grid>
             <Grid item xs={12} sm={4}>
               <Button
@@ -741,7 +771,7 @@ function ShipmentInfo(props) {
                 disabled={shipmentFormData === null}
                 className={classes.submit}
               >
-                {`Next: Add Items`}
+                {`Next: Items`}
               </Button>
             </Grid>
           </Grid>

--- a/src/midgard/pages/Shipment/components/ShipmentInfo.js
+++ b/src/midgard/pages/Shipment/components/ShipmentInfo.js
@@ -309,7 +309,7 @@ function ShipmentInfo(props) {
       <div>
         {!isDesktop && (
           <Box mb={2}>
-            <Typography variant="h4">Shipment Details(1/5)</Typography>
+            <Typography variant="h4">Shipment Details (1/5)</Typography>
           </Box>
         )}
         <form className={classes.form} noValidate onSubmit={handleSubmit}>
@@ -412,7 +412,7 @@ function ShipmentInfo(props) {
                       {TRANSPORT_MODE &&
                         TRANSPORT_MODE.sort(compareSort("value")).map(
                           (item, index) => (
-                            <MenuItem key={`${item.value}`} value={item.value}>
+                            <MenuItem key={`transportMode${index}:${item.value}`} value={item.value}>
                               {item.label}
                             </MenuItem>
                           )
@@ -484,7 +484,7 @@ function ShipmentInfo(props) {
                           .sort(compareSort("name"))
                           .map((item, index) => (
                             <MenuItem
-                              key={`${item.id}${item.name}`}
+                              key={`temperature${index}:${item.id}`}
                               value={item.url}
                             >
                               {item.name}
@@ -526,7 +526,7 @@ function ShipmentInfo(props) {
                       {SHIPMENT_STATUS &&
                         SHIPMENT_STATUS.sort(compareSort("value")).map(
                           (item, index) => (
-                            <MenuItem key={`${item.value}`} value={item.value}>
+                            <MenuItem key={`shipmentStatus${index}:${item.value}`} value={item.value}>
                               {item.label}
                             </MenuItem>
                           )
@@ -650,7 +650,7 @@ function ShipmentInfo(props) {
                           .sort(compareSort("name"))
                           .map((item, index) => (
                             <MenuItem
-                              key={`${item.id}${item.name}`}
+                              key={`lengthUnit${index}:${item.id}`}
                               value={item.url}
                             >
                               {item.name}
@@ -694,7 +694,7 @@ function ShipmentInfo(props) {
                           .sort(compareSort("name"))
                           .map((item, index) => (
                             <MenuItem
-                              key={`${item.id}${item.name}`}
+                              key={`weightUnit${index}:${item.id}`}
                               value={item.url}
                             >
                               {item.name}

--- a/src/midgard/pages/Shipment/components/ShipmentList.js
+++ b/src/midgard/pages/Shipment/components/ShipmentList.js
@@ -375,11 +375,11 @@ export default function ShipmentList({ ...props }) {
               filteredRows
 
                 // .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map((row, idx) => {
+                .map((row, rowIndex) => {
                   return (
-                    <React.Fragment key={`tableRow${idx}`}>
+                    <React.Fragment key={`row${rowIndex}:${row.id}`}>
                       <StyledTableRow hover tabIndex={-1}>
-                        <TableCell key={row.id} colSpan={3}>
+                        <TableCell colSpan={3}>
                           <Table>
                             <TableBody>
                               <TableRow>
@@ -430,7 +430,7 @@ export default function ShipmentList({ ...props }) {
                                   </IconButton>
                                 </TableCell>
                                 {columns &&
-                                  columns.map((column) => {
+                                  columns.map((column, colIndex) => {
                                     if (column.id !== "id") {
                                       const value = row[column.id] || "-";
                                       return (
@@ -441,7 +441,7 @@ export default function ShipmentList({ ...props }) {
                                             minWidth: column.minWidth,
                                           }}
                                           className={classes.tableCell}
-                                          key={column.id}
+                                          key={`row${rowIndex}col${colIndex}:${row.id}`}
                                           align="left"
                                           title={
                                             column.format

--- a/src/midgard/pages/Shipment/components/ShipmentList.js
+++ b/src/midgard/pages/Shipment/components/ShipmentList.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Paper from "@material-ui/core/Paper";
@@ -10,6 +10,7 @@ import TableHead from "@material-ui/core/TableHead";
 import TablePagination from "@material-ui/core/TablePagination";
 import TableRow from "@material-ui/core/TableRow";
 import EditIcon from "@material-ui/icons/Edit";
+import ViewIcon from "@material-ui/icons/RemoveRedEye";
 import DeleteIcon from "@material-ui/icons/Delete";
 import IconButton from "@material-ui/core/IconButton";
 import SearchInput from "../../../components/SearchComponent/SearchInput";
@@ -19,6 +20,8 @@ import ShipmentFilterAndSort from "./ShipmentFilterAndSort";
 import { dispatch } from "../../../redux/store";
 import { filterShipmentData } from "../../../redux/shipment/actions/shipment.actions";
 import Loader from "../../../components/Loader/Loader";
+import { checkForGlobalAdmin } from "midgard/utils/utilMethods";
+import { UserContext } from "midgard/context/User.context";
 
 const StyledTableRow = withStyles((theme) => ({
   root: {
@@ -106,6 +109,9 @@ export default function ShipmentList({ ...props }) {
   const [plannedCheck, setPlannedCheck] = useState(null);
   const [cancelledCheck, setCancelledCheck] = useState(null);
   const [completedCheck, setCompeletedCheck] = useState(null);
+  const editData = location.state && location.state.data;
+  const user = useContext(UserContext);
+  const isAdmin = checkForGlobalAdmin(user);
 
   const handleAllCheck = (e) => {
     setAllCheck(e.target.checked);
@@ -408,7 +414,7 @@ export default function ShipmentList({ ...props }) {
                                     color="secondary"
                                     aria-label="menu"
                                   >
-                                    <EditIcon />
+                                    {!isAdmin && row && row.status && row.status.toLowerCase() !== 'planned' ? <ViewIcon /> : <EditIcon />}
                                   </IconButton>
                                 </TableCell>
                                 <TableCell

--- a/src/midgard/pages/Shipment/components/custodian-info/AddCustodyForm.js
+++ b/src/midgard/pages/Shipment/components/custodian-info/AddCustodyForm.js
@@ -74,7 +74,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function AddCustodyInfo(props) {
+function AddCustodyForm(props) {
   const {
     custodianData,
     loading,
@@ -84,6 +84,7 @@ function AddCustodyInfo(props) {
     editItem,
     setOpenModal,
     custodyOptions,
+    viewOnly
   } = props;
   const classes = useStyles();
   const [custodianId, setCustodianId] = useState(
@@ -264,7 +265,7 @@ function AddCustodyInfo(props) {
                   fullWidth
                   disabled
                   id="shipment_name"
-                  label="Shipment Name"
+                  label="Shipment name"
                   name="shipment_name"
                   autoComplete="shipment_name"
                   {...shipment_name.bind}
@@ -279,6 +280,7 @@ function AddCustodyInfo(props) {
                   select
                   required
                   label="Custodian"
+                  disabled={viewOnly}
                   error={formError.custodianId && formError.custodianId.error}
                   helperText={
                     formError.custodianId ? formError.custodianId.message : ""
@@ -318,9 +320,10 @@ function AddCustodyInfo(props) {
               </Grid>
               <Grid item xs={12}>
                 <DatePickerComponent
-                  label={"Start of custody"}
+                  label={"Start of Custody"}
                   selectedDate={start_of_custody}
                   hasTime={true}
+                  disabled={viewOnly}
                   helpText={
                     custodyMetaData["start_of_custody"] &&
                     custodyMetaData["start_of_custody"].help_text
@@ -332,10 +335,11 @@ function AddCustodyInfo(props) {
               </Grid>
               <Grid item xs={12}>
                 <DatePickerComponent
-                  label={"End of custody"}
+                  label={"End of Custody"}
                   selectedDate={end_of_custody}
                   hasTime={true}
                   handleDateChange={handleEndChange}
+                  disabled={viewOnly}
                   helpText={
                     custodyMetaData["end_of_custody"] &&
                     custodyMetaData["end_of_custody"].help_text
@@ -350,10 +354,11 @@ function AddCustodyInfo(props) {
                   margin="normal"
                   fullWidth
                   id="start_of_custody_location"
-                  label="Start Of Custody Location"
+                  label="Start of Custody location"
                   name="start_of_custody_location"
                   autoComplete="start_of_custody_location"
                   value={start_of_custody_location}
+                  disabled={viewOnly}
                   InputProps={
                     custodyMetaData["start_of_custody_location"] &&
                     custodyMetaData["start_of_custody_location"].help_text && {
@@ -400,10 +405,11 @@ function AddCustodyInfo(props) {
                   margin="normal"
                   fullWidth
                   id="end_of_custody_location"
-                  label="End Of Custody Location"
+                  label="End of Custody location"
                   name="end_of_custody_location"
                   autoComplete="end_of_custody_location"
                   value={end_of_custody_location}
+                  disabled={viewOnly}
                   InputProps={
                     custodyMetaData["end_of_custody_location"] &&
                     custodyMetaData["end_of_custody_location"].help_text && {
@@ -451,7 +457,8 @@ function AddCustodyInfo(props) {
                   fullWidth
                   id="has_current_custody"
                   select
-                  label="Has Current Custody"
+                  disabled={viewOnly}
+                  label="Has current Custody?"
                   {...has_current_custody.bind}
                   InputProps={
                     custodyMetaData["has_current_custody"] &&
@@ -481,7 +488,8 @@ function AddCustodyInfo(props) {
                   fullWidth
                   id="first_custody"
                   select
-                  label="Is First Custody"
+                  disabled={viewOnly}
+                  label="Is first Custody?"
                   {...first_custody.bind}
                   InputProps={
                     custodyMetaData["first_custody"] &&
@@ -511,7 +519,8 @@ function AddCustodyInfo(props) {
                   fullWidth
                   id="last_custody"
                   select
-                  label="Is Last Custody"
+                  disabled={viewOnly}
+                  label="Is last Custody?"
                   {...last_custody.bind}
                   InputProps={
                     custodyMetaData["last_custody"] &&
@@ -562,24 +571,37 @@ function AddCustodyInfo(props) {
         </Card>
         <Grid container spacing={3} className={classes.buttonContainer}>
           <Grid item xs={6}>
-            <div className={classes.loadingWrapper}>
+            {viewOnly ? (
               <Button
-                type="submit"
+                type="button"
                 fullWidth
                 variant="contained"
                 color="primary"
                 className={classes.submit}
-                disabled={loading || submitDisabled()}
+                onClick={setOpenModal}
               >
-                {editItem ? "Save" : `Add Custody`}
+                Done
               </Button>
-              {loading && (
-                <CircularProgress
-                  size={24}
-                  className={classes.buttonProgress}
-                />
-              )}
-            </div>
+            ) : (
+              <div className={classes.loadingWrapper}>
+                <Button
+                  type="submit"
+                  fullWidth
+                  variant="contained"
+                  color="primary"
+                  className={classes.submit}
+                  disabled={loading || submitDisabled()}
+                >
+                  {editItem ? "Save" : `Add Custody`}
+                </Button>
+                {loading && (
+                  <CircularProgress
+                    size={24}
+                    className={classes.buttonProgress}
+                  />
+                )}
+              </div>
+            )}
           </Grid>
         </Grid>
       </form>
@@ -593,4 +615,4 @@ function AddCustodyInfo(props) {
 //   ...state.shipmentReducer,
 // });
 
-export default AddCustodyInfo;
+export default AddCustodyForm;

--- a/src/midgard/pages/Shipment/components/custodian-info/AddCustodyForm.js
+++ b/src/midgard/pages/Shipment/components/custodian-info/AddCustodyForm.js
@@ -310,7 +310,7 @@ function AddCustodyInfo(props) {
                     custodianList
                       .sort(compareSort("name"))
                       .map((item, index) => (
-                        <MenuItem key={`${item.id}${item.name}`} value={item}>
+                        <MenuItem key={`custodian${index}:${item.id}`} value={item}>
                           {`${item.name}:${item.custodian_uuid}`}
                         </MenuItem>
                       ))}

--- a/src/midgard/pages/Shipment/components/custodian-info/CustodianInfo.js
+++ b/src/midgard/pages/Shipment/components/custodian-info/CustodianInfo.js
@@ -81,10 +81,12 @@ function CustodianInfo(props) {
     redirectTo,
     loading,
     handleNext,
+    handleCancel,
     shipmentFormData,
     dispatch,
     contactInfo,
     custodyData,
+    viewOnly
   } = props;
   const [itemIds, setItemIds] = useState(
     (shipmentFormData && shipmentFormData.custodian_ids) || []
@@ -138,7 +140,7 @@ function CustodianInfo(props) {
     setOpenModal(false);
   };
 
-  const deletItem = (item) => {
+  const deleteItem = (item) => {
     let index = itemIds.indexOf(item.custodian_uuid);
     let newArr = itemIds.filter((item, idx) => idx !== index);
     const shipmentFormValue = {
@@ -165,12 +167,12 @@ function CustodianInfo(props) {
   };
 
   const actionsColumns = [
-    // { id: "unlink", type: "unlink", action: deletItem, label: "Unassociate" },
+    // { id: "unlink", type: "unlink", action: deleteItem, label: "Unassociate" },
     {
       id: "edit",
-      type: "edit",
+      type: viewOnly ? "view" : "edit",
       action: editCustody,
-      label: "Edit",
+      label: viewOnly ? "View" : "Edit",
     },
   ];
 
@@ -179,6 +181,7 @@ function CustodianInfo(props) {
       <Button
         variant="contained"
         color="primary"
+        disabled={viewOnly}
         onClick={() => setOpenModal(true)}
         className={classes.submit}
       >
@@ -206,7 +209,7 @@ function CustodianInfo(props) {
           <Modal
             open={openModal}
             setOpen={() => oncloseModal()}
-            title={editItem ? "Edit Custody" : "Add Custody"}
+            title={editItem ? viewOnly ? "View Custody" : "Edit Custody" : "Add Custody"}
             titleClass={classes.formTitle}
             maxWidth={"md"}
           >
@@ -215,6 +218,7 @@ function CustodianInfo(props) {
               itemIds={itemIds}
               setOpenModal={() => oncloseModal()}
               rows={rows}
+              viewOnly={viewOnly}
               editItem={editItem}
               {...props}
             />
@@ -222,6 +226,20 @@ function CustodianInfo(props) {
         )}
       </Box>
       <Grid container spacing={3} className={classes.buttonContainer}>
+          {viewOnly && (
+            <Grid item xs={6} sm={2}>
+              <Button
+                type="button"
+                fullWidth
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+                onClick={handleCancel}
+              >
+                Done
+              </Button>
+            </Grid>
+          )}
         <Grid item xs={12} sm={4}>
           <Button
             variant="contained"
@@ -230,7 +248,7 @@ function CustodianInfo(props) {
             onClick={handleNext}
             className={classes.submit}
           >
-            {`Next: Add Sensors & Gateways`}
+            {`Next: Sensors & Gateways`}
           </Button>
         </Grid>
       </Grid>

--- a/src/midgard/pages/Shipment/forms/AddDestinationInfo.js
+++ b/src/midgard/pages/Shipment/forms/AddDestinationInfo.js
@@ -300,8 +300,8 @@ function AddDestinationInfo({
                       {...country.bind}
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {COUNTRY_CHOICES.map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {COUNTRY_CHOICES.map((value, index) => (
+                        <MenuItem key={`destCountry${index}:${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}
@@ -324,8 +324,8 @@ function AddDestinationInfo({
                       {...state.bind}
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {STATE_CHOICES.map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {STATE_CHOICES.map((value, index) => (
+                        <MenuItem key={`destState${index}:${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}

--- a/src/midgard/pages/Shipment/forms/AddOriginInfo.js
+++ b/src/midgard/pages/Shipment/forms/AddOriginInfo.js
@@ -311,8 +311,8 @@ function AddOriginInfo({
                       {...country.bind}
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {COUNTRY_CHOICES.map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {COUNTRY_CHOICES.map((value, index) => (
+                        <MenuItem key={`originCountry${index}:${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}
@@ -335,8 +335,8 @@ function AddOriginInfo({
                       {...state.bind}
                     >
                       <MenuItem value={""}>Select</MenuItem>
-                      {STATE_CHOICES.map((value, id) => (
-                        <MenuItem key={value} value={value}>
+                      {STATE_CHOICES.map((value, index) => (
+                        <MenuItem key={`originState${index}:${value}`} value={value}>
                           {value}
                         </MenuItem>
                       ))}

--- a/src/midgard/pages/Shipment/forms/AddShipment.js
+++ b/src/midgard/pages/Shipment/forms/AddShipment.js
@@ -232,7 +232,7 @@ function AddShipment(props) {
                   <Stepper activeStep={activeStep} alternativeLabel nonLinear>
                     {steps.map((label, index) => (
                       <Step
-                        key={label}
+                        key={`step${index}:${label}`}
                         className={`${
                           shipmentFormData !== null && classes.step
                         }`}

--- a/src/midgard/pages/Shipment/forms/AddShipment.js
+++ b/src/midgard/pages/Shipment/forms/AddShipment.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Stepper from "@material-ui/core/Stepper";
 import Step from "@material-ui/core/Step";
@@ -16,12 +16,14 @@ import Items from "../../Items/Items";
 import { routes } from "../../../routes/routesConstants";
 import SensorsGateway from "../../SensorsGateway/SensorsGateway";
 import ShipmentOverview from "../components/ShipmentOverview";
-import ItemsInfo from "../components/ItemInfo";
+import ItemInfo from "../components/ItemInfo";
 import { saveShipmentFormData } from "../../../redux/shipment/actions/shipment.actions";
 import { connect } from "react-redux";
 import SensorsGatewayInfo from "../components/Sensors&GatewayInfo";
 import EnvironmentalLimitsInfo from "../components/EnvironmentalLimitsInfo";
 import CustodianInfo from "../components/custodian-info/CustodianInfo";
+import { checkForGlobalAdmin } from "midgard/utils/utilMethods";
+import { UserContext } from "midgard/context/User.context";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -62,6 +64,7 @@ function getSteps() {
 const getStepContent = (
   stepIndex,
   props,
+  viewOnly,
   handleNext,
   handleBack,
   maxSteps,
@@ -79,6 +82,7 @@ const getStepContent = (
         >
           <ShipmentInfo
             {...props}
+            viewOnly={viewOnly}
             location={props.location}
             handleNext={handleNext}
             handleBack={handleBack}
@@ -96,8 +100,9 @@ const getStepContent = (
           maxSteps={maxSteps}
           activeStep={stepIndex}
         >
-          <ItemsInfo
+          <ItemInfo
             {...props}
+            viewOnly={viewOnly}
             history={props.history}
             redirectTo={`${routes.SHIPMENT}/add`}
             handleNext={handleNext}
@@ -116,6 +121,7 @@ const getStepContent = (
         >
           <CustodianInfo
             {...props}
+            viewOnly={viewOnly}
             history={props.history}
             redirectTo={`${routes.SHIPMENT}/add`}
             handleNext={handleNext}
@@ -135,6 +141,7 @@ const getStepContent = (
         >
           <SensorsGatewayInfo
             {...props}
+            viewOnly={viewOnly}
             history={props.history}
             redirectTo={`${routes.SHIPMENT}/add`}
             handleNext={handleNext}
@@ -153,6 +160,7 @@ const getStepContent = (
         >
           <EnvironmentalLimitsInfo
             {...props}
+            viewOnly={viewOnly}
             history={props.history}
             redirectTo={`${routes.SHIPMENT}/add`}
             handleNext={handleNext}
@@ -183,12 +191,20 @@ const getStepContent = (
 function AddShipment(props) {
   const { location, history, shipmentFormData, dispatch } = props;
   const editPage = location.state && location.state.type === "edit";
+  const editData = location.state && location.state.data;
+  const user = useContext(UserContext);
+  // For non-admins the forms becomes view-only once the shipment status is no longer just planned
+  const viewOnly = !(checkForGlobalAdmin(user)) && editPage && editData && editData.status && editData.status.toLowerCase() !== "planned";
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
   const [openModal, toggleModal] = useState(true);
   const steps = getSteps();
   const maxSteps = steps.length;
-  const formTitle = editPage ? "Edit Shipment" : "Add Shipment";
+  const formTitle = editPage
+    ? viewOnly
+      ? "View Shipment"
+      : "Edit Shipment"
+    : "Add Shipment";
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
@@ -251,6 +267,7 @@ function AddShipment(props) {
                 {getStepContent(
                   activeStep,
                   props,
+                  viewOnly,
                   handleNext,
                   handleBack,
                   maxSteps,

--- a/src/midgard/pages/Shipment/forms/AddShipperInfo.js
+++ b/src/midgard/pages/Shipment/forms/AddShipperInfo.js
@@ -211,7 +211,7 @@ function AddShipperInfo({
                   <MenuItem value={""}>Select</MenuItem>
                   {modeTypeList &&
                     modeTypeList.map((item, index) => (
-                      <MenuItem key={`${item.id}${item.name}`} value={item.url}>
+                      <MenuItem key={`modeType${index}:${item.id}`} value={item.url}>
                         {item.name}
                       </MenuItem>
                     ))}

--- a/src/midgard/pages/UserManagement/UserGroups/UserGroups.js
+++ b/src/midgard/pages/UserManagement/UserGroups/UserGroups.js
@@ -70,14 +70,14 @@ function UserGroups() {
       <React.Fragment>
         <IconButton
           aria-label="more"
-          aria-controls={'group-actions-menu-' + row.id}
+          aria-controls={`groupActions${row.id}`}
           aria-haspopup="true"
           onClick={handleMenuClick}
         >
           <MoreHoriz />
         </IconButton>
         <Menu
-          id={'group-actions-menu-' + row.id}
+          id={`groupActions${row.id}`}
           anchorEl={menu.element}
           keepMounted
           open={menu.row && (menu.row.id === row.id) || false}
@@ -85,7 +85,7 @@ function UserGroups() {
         >
           {row.actions.map((option) => (
           <MenuItem
-            key={'group-actions-' + row.id + '-' + option.value}
+            key={`groupActions${row.id}:${option.value}`}
             onClick={() => handleMenuItemClick(option.value)}
           >
             {option.label}

--- a/src/midgard/pages/UserManagement/UserManagement.js
+++ b/src/midgard/pages/UserManagement/UserManagement.js
@@ -138,7 +138,7 @@ function UserManagement({ dispatch, loading, error, user, history, location }) {
       </Box>
       <Box mb={3}>
         <Tabs value={view} onChange={viewTabClicked}>
-          {subNav.map(itemProps => <Tab {...itemProps} key={'tab-view-' + itemProps.value} />)}
+          {subNav.map((itemProps, index) => <Tab {...itemProps} key={`tab${index}:${itemProps.value}`} />)}
         </Tabs>
       </Box>
       <Route path={routes.CURRENT_USERS} component={Users} />

--- a/src/midgard/pages/UserManagement/Users/Users.js
+++ b/src/midgard/pages/UserManagement/Users/Users.js
@@ -51,7 +51,7 @@ function Users({ location, history, data, dispatch }) {
         {permissions.map((permission, index) => (
           <Button
             className={classes.btnPermission}
-            key={'btn-group-'+index}
+            key={`btnGroup${index}`}
             variant={permission.value === active ? "contained" : "outlined"}
             onClick={() => {
               setActive(permission.value);
@@ -88,14 +88,14 @@ function Users({ location, history, data, dispatch }) {
       <React.Fragment>
         <IconButton
           aria-label="more"
-          aria-controls={'user-actions-menu-' + row.id}
+          aria-controls={`userActions${row.id}`}
           aria-haspopup="true"
           onClick={handleMenuClick}
         >
           <MoreHoriz />
         </IconButton>
         <Menu
-          id={'user-actions-menu-' + row.id}
+          id={`userActions${row.id}`}
           anchorEl={menu.element}
           keepMounted
           open={Boolean(menu.row && (menu.row.id === row.id))}
@@ -103,7 +103,7 @@ function Users({ location, history, data, dispatch }) {
         >
           {row.actions.map((option) => (
           <MenuItem
-            key={'user-actions-' + row.id + '-' + option.value}
+            key={`userActions${row.id }:${option.value}`}
             onClick={() => handleMenuItemClick(option.value)}
           >
             {option.label}


### PR DESCRIPTION
## Purpose
Disables the editing of the shipment form when the status is not planned unless the user is a global admin. 'Edit' icons are replaced by 'View' icons in this case.

## Further info
I also fixed some console errors caused by duplicate `key` properties and removed unnecessary text capitalization.

## Ticket number
#39 
