### PR TITLE
Filter user management groups by the organization of the admin

### DIFF
--- a/src/midgard/layout/Container/Container.js
+++ b/src/midgard/layout/Container/Container.js
@@ -18,7 +18,7 @@ import Items from "../../pages/Items/Items";
 import SensorsGateway from "../../pages/SensorsGateway/SensorsGateway";
 import Shipment from "../../pages/Shipment/Shipment";
 import Dashboard from "../../pages/Dashboard/Dashboard";
-import { checkForAdmin } from "../../utils/utilMethods";
+import { checkForAdmin, checkForGlobalAdmin } from "../../utils/utilMethods";
 import { isMobile } from "../../utils/mediaQuery";
 
 const useStyles = makeStyles((theme) => ({
@@ -93,7 +93,7 @@ function ContainerDashboard({ location, history, data }) {
             render={() => <Redirect to={routes.DASHBOARD} />}
           />
           <Route path={routes.DASHBOARD} component={Dashboard} />
-          {checkForAdmin(userData) && (
+          {(checkForAdmin(userData) || checkForGlobalAdmin(userData)) && (
             <Route path={routes.USER_MANAGEMENT} component={UserManagement} />
           )}
           <Route path={routes.CUSTODIANS} component={Custodians} />

--- a/src/midgard/layout/Container/Container.js
+++ b/src/midgard/layout/Container/Container.js
@@ -18,7 +18,7 @@ import Items from "../../pages/Items/Items";
 import SensorsGateway from "../../pages/SensorsGateway/SensorsGateway";
 import Shipment from "../../pages/Shipment/Shipment";
 import Dashboard from "../../pages/Dashboard/Dashboard";
-import { checkForGlobalAdmin } from "../../utils/utilMethods";
+import { checkForAdmin } from "../../utils/utilMethods";
 import { isMobile } from "../../utils/mediaQuery";
 
 const useStyles = makeStyles((theme) => ({
@@ -93,7 +93,7 @@ function ContainerDashboard({ location, history, data }) {
             render={() => <Redirect to={routes.DASHBOARD} />}
           />
           <Route path={routes.DASHBOARD} component={Dashboard} />
-          {checkForGlobalAdmin(userData) && (
+          {checkForAdmin(userData) && (
             <Route path={routes.USER_MANAGEMENT} component={UserManagement} />
           )}
           <Route path={routes.CUSTODIANS} component={Custodians} />

--- a/src/midgard/layout/NavBar/NavBar.js
+++ b/src/midgard/layout/NavBar/NavBar.js
@@ -10,7 +10,7 @@ import { makeStyles, useTheme } from "@material-ui/core/styles";
 import { AppContext } from "midgard/context/App.context";
 import { NAVIGATION_ITEMS } from "./NavBarConstants";
 import { isMobile } from "../../utils/mediaQuery";
-import { checkForGlobalAdmin } from "../../utils/utilMethods";
+import { checkForAdmin } from "../../utils/utilMethods";
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
@@ -60,9 +60,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const getFilteredNavItems = (userData, navItems) => {
-  let isGlobalAdmin = checkForGlobalAdmin(userData);
-
-  if (isGlobalAdmin) return navItems;
+  let isAdmin = checkForAdmin(userData);
+  
+  if (isAdmin) return navItems;
   else
     return navItems.filter((nav) => {
       return nav.id !== "user_management";

--- a/src/midgard/layout/NavBar/NavBar.js
+++ b/src/midgard/layout/NavBar/NavBar.js
@@ -10,7 +10,7 @@ import { makeStyles, useTheme } from "@material-ui/core/styles";
 import { AppContext } from "midgard/context/App.context";
 import { NAVIGATION_ITEMS } from "./NavBarConstants";
 import { isMobile } from "../../utils/mediaQuery";
-import { checkForAdmin } from "../../utils/utilMethods";
+import { checkForAdmin, checkForGlobalAdmin } from "../../utils/utilMethods";
 
 const useStyles = makeStyles((theme) => ({
   drawer: {
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const getFilteredNavItems = (userData, navItems) => {
-  let isAdmin = checkForAdmin(userData);
+  let isAdmin = checkForAdmin(userData) || checkForGlobalAdmin(userData);
   
   if (isAdmin) return navItems;
   else

--- a/src/midgard/pages/Register/Register.js
+++ b/src/midgard/pages/Register/Register.js
@@ -96,7 +96,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
       username: username.value,
       email: email.value,
       password: password.value,
-      organization: { name: organization_name.value },
+      organization_name: organization_name.value,
       first_name: first_name.value,
       last_name: last_name.value,
     };

--- a/src/midgard/pages/UserManagement/Users/Users.js
+++ b/src/midgard/pages/UserManagement/Users/Users.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { PermissionsTable } from 'midgard/components/PermissionsTable/PermissionsTable';
 import Crud from 'midgard/modules/crud/Crud';
 import { getCoreGroups } from 'midgard/redux/coregroup/actions/coregroup.actions'
@@ -13,6 +13,8 @@ import Box from "@material-ui/core/Box";
 import { makeStyles } from '@material-ui/core/styles';
 import { rem } from 'polished';
 import { Typography } from '@material-ui/core';
+import { checkForGlobalAdmin, checkForAdmin } from "midgard/utils/utilMethods";
+import { UserContext } from "midgard/context/User.context";
 
 const useStyles = makeStyles((theme) => ({
   btnPermission: {
@@ -29,7 +31,10 @@ function Users({ location, history, data, dispatch }) {
   const [menu, setMenu] = useState({ row: null, element: null });
   const [coreGroupsLoaded, setCoreGroupsLoaded] = useState(false);
   const [permissions, setPermissions] = useState([]);
-
+  // to get currently logged in user
+  const user = useContext(UserContext);
+  const isOrganizationAdmin = checkForAdmin(user);
+ 
   useEffect(() => {
     if (!coreGroupsLoaded) {
       dispatch(getCoreGroups());
@@ -139,10 +144,23 @@ function Users({ location, history, data, dispatch }) {
             });
           }
           return (
+            isOrganizationAdmin ?
             <PermissionsTable
               columns={[
                 { label: 'Full name', prop: 'name', template: (row) => {return <Typography variant="body1" style={!row.is_active? {'color': '#aaa'}: null}>{row.first_name} {row.last_name}</Typography>}, flex: '1' },
-                { label: 'Email', prop: 'email', flex: '2', template: (row) => {return <Typography variant="body2" style={!row.is_active? {'color': '#aaa'}: null}> {row.email}</Typography>}},
+                { label: 'Email', prop: 'email', flex: '2', template: (row) => {return <Typography variant="body2" style={!row.is_active? {'color': '#aaa'}: null}>{row.email}</Typography>}},
+                { label: 'Last activity', prop: 'activity', template: (row) => {return <Typography variant="caption" style={{'color': '#aaa'}}>Today</Typography>}, flex: '1' },
+                { label: 'Permissions', prop: 'permission', template: (row) => permissionsTemplate(row, crud, classes), flex: '2' },
+                { label: 'Actions', prop: 'options', template: (row) => actionsTemplate(row, crud), flex: '1' },
+              ]}
+              rows={crud.getData()}
+            />
+            :
+            <PermissionsTable
+              columns={[
+                { label: 'Full name', prop: 'name', template: (row) => {return <Typography variant="body1" style={!row.is_active? {'color': '#aaa'}: null}>{row.first_name} {row.last_name}</Typography>}, flex: '1' },
+                { label: 'Email', prop: 'email', flex: '2', template: (row) => {return <Typography variant="body2" style={!row.is_active? {'color': '#aaa'}: null}>{row.email}</Typography>}},
+                { label: 'Organization name', prop: 'organization', flex: '2', template: (row) => {return <Typography variant="body2" style={!row.is_active? {'color': '#aaa'}: null}>{row.organization.name}</Typography>}},
                 { label: 'Last activity', prop: 'activity', template: (row) => {return <Typography variant="caption" style={{'color': '#aaa'}}>Today</Typography>}, flex: '1' },
                 { label: 'Permissions', prop: 'permission', template: (row) => permissionsTemplate(row, crud, classes), flex: '2' },
                 { label: 'Actions', prop: 'options', template: (row) => actionsTemplate(row, crud), flex: '1' },

--- a/src/midgard/utils/utilMethods.js
+++ b/src/midgard/utils/utilMethods.js
@@ -77,10 +77,7 @@ export const checkForAdmin = (userData) => {
   let isAdmin = false;
   if (userData && userData.core_groups) {
     userData.core_groups.map((group) => {
-      if (group.is_org_level && group.name.toLowerCase().includes("admin")) {
-        isAdmin = true;
-      }
-      else if (group.is_global) {
+      if (group.is_org_level && group.name.toLowerCase().includes("admin") && !group.is_global) {
         isAdmin = true;
       }
     });

--- a/src/midgard/utils/utilMethods.js
+++ b/src/midgard/utils/utilMethods.js
@@ -65,7 +65,8 @@ export const checkForGlobalAdmin = (userData) => {
   let isGlobalAdmin = false;
   if (userData && userData.core_groups) {
     userData.core_groups.map((group) => {
-      if (group.is_global) {
+      if (group.is_global &&
+        Object.keys(group.permissions).every((permission) => group.permissions[permission] === true)) {
         isGlobalAdmin = true;
       }
     });
@@ -77,7 +78,9 @@ export const checkForAdmin = (userData) => {
   let isAdmin = false;
   if (userData && userData.core_groups) {
     userData.core_groups.map((group) => {
-      if (group.is_org_level && group.name.toLowerCase().includes("admin") && !group.is_global) {
+      if (group.is_org_level &&
+        Object.keys(group.permissions).every((permission) => group.permissions[permission] === true) &&
+        !group.is_global) {
         isAdmin = true;
       }
     });

--- a/src/midgard/utils/utilMethods.js
+++ b/src/midgard/utils/utilMethods.js
@@ -73,6 +73,21 @@ export const checkForGlobalAdmin = (userData) => {
   return isGlobalAdmin;
 };
 
+export const checkForAdmin = (userData) => {
+  let isAdmin = false;
+  if (userData && userData.core_groups) {
+    userData.core_groups.map((group) => {
+      if (group.is_org_level && group.name.toLowerCase().includes("admin")) {
+        isAdmin = true;
+      }
+      else if (group.is_global) {
+        isAdmin = true;
+      }
+    });
+  }
+  return isAdmin;
+}
+
 export const setOptionsData = (options, fieldName) => {
   let result = null;
   let optionKeys = Object.keys(options);


### PR DESCRIPTION
## Purpose
_To show a filtered view of users by admin's organization details. For global admin, the user's organization name is to be shown also_

## Further info
_1. Global Admin - See all users with their organization name besides
2. Admin - See users filtered by organization_

## Ticket number
_14_

## Issue Link
_https://github.com/buildlyio/buildly-react-template/issues/14_