### PR TITLE
Remove planned shipments from violations table

### DIFF
--- a/src/midgard/pages/Dashboard/Dashboard.js
+++ b/src/midgard/pages/Dashboard/Dashboard.js
@@ -218,7 +218,9 @@ function Dashboard(props) {
               excursionInfo.forEach((item) => {
                 itemExists = item.url === row.url;
               });
-              if (!itemExists) excursionInfo.push(row);
+              if (!itemExists && row.status.toLowerCase() !== 'planned') {
+                excursionInfo.push(row);
+              }
             }
           });
         }


### PR DESCRIPTION
## Purpose
Removes planned shipments from the violations and recalls table on the dashboard.

## Further info
@glind I'm not sure what the desired behaviour is. I filtered out shipments with the `Planned` status. Currently `Enroute`, `Cancelled` and `Completed` are all shown. Is this correct?

## Ticket number
#44 