### PR TITLE
GeoFence Alerts (FE to BE)

### DIFF
--- a/src/modules/oauth/oauth.service.js
+++ b/src/modules/oauth/oauth.service.js
@@ -130,8 +130,7 @@ const logout = () => {
     localStorage.removeItem('token_stored_at');
     localStorage.removeItem('oauthUser');
     localStorage.removeItem('currentUser');
-    localStorage.removeItem('sensorAlerts');
-    localStorage.removeItem('geofenceAlerts');
+    localStorage.removeItem('viewedAlerts');
   }
 };
 

--- a/src/pages/Reporting/Reporting.js
+++ b/src/pages/Reporting/Reporting.js
@@ -194,7 +194,7 @@ const Reporting = ({
       }
     }
 
-    if (shipmentData) {
+    if (shipmentData && shipmentData.length) {
       const ships = _.filter(shipmentData, { had_alert: true });
       const ids = _.toString(_.map(ships, 'partner_shipment_id'));
       const encodedIds = encodeURIComponent(ids);

--- a/src/pages/Reporting/components/AlertsReport.js
+++ b/src/pages/Reporting/components/AlertsReport.js
@@ -45,8 +45,12 @@ const AlertsReport = ({
 
   useEffect(() => {
     if (alerts) {
-      const sortedData = _.orderBy(
+      const filteredData = _.filter(
         alerts,
+        (alert) => alert.parameter_type !== 'location',
+      );
+      const sortedData = _.orderBy(
+        filteredData,
         (item) => moment(item.create_date),
         ['desc'],
       );

--- a/src/pages/Shipment/AlertInfo.js
+++ b/src/pages/Shipment/AlertInfo.js
@@ -3,12 +3,6 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 import { makeStyles } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { UserContext } from '@context/User.context';
-import { updateCustody } from '@redux/custodian/actions/custodian.actions';
-import {
-  editShipment,
-  emailAlerts,
-} from '@redux/shipment/actions/shipment.actions';
 import { getFormattedCustodyRows } from './ShipmentConstants';
 
 const useStyles = makeStyles((theme) => ({
@@ -52,357 +46,206 @@ const useStyles = makeStyles((theme) => ({
 const AlertInfo = ({
   shipmentData,
   shipmentFlag,
-  dispatch,
-  geofenceAlerts,
   custodyData,
   custodianData,
   sensorAlerts,
 }) => {
   const classes = useStyles();
-  const [senAlerts, setSenAlerts] = useState([]);
-  const [geoAlerts, setGeoAlerts] = useState([]);
-  const { organization_uuid } = useContext(UserContext).organization;
+  const [alerts, setAlerts] = useState([]);
 
   useEffect(() => {
     if (
       shipmentData
-      && shipmentFlag
       && sensorAlerts
       && shipmentData.length > 0
-      && shipmentFlag.length > 0
       && sensorAlerts.length > 0
     ) {
-      let alerts = [];
-      const viewedSensorAlerts = localStorage.getItem('sensorAlerts')
-        ? JSON.parse(localStorage.getItem('sensorAlerts'))
+      let alertsArray = [];
+      let custodyRows = [];
+      const viewedAlerts = localStorage.getItem('viewedAlerts')
+        ? JSON.parse(localStorage.getItem('viewedAlerts'))
         : [];
+
+      if (
+        custodyData
+        && custodianData
+        && custodyData.length > 0
+        && custodianData.length > 0
+      ) {
+        custodyRows = getFormattedCustodyRows(custodyData, custodianData);
+      }
 
       _.forEach(shipmentData, (shipment) => {
         const shipmentAlerts = _.filter(
           sensorAlerts,
-          { shipment_id: shipment.partner_shipment_id },
+          { 
+            shipment_id: shipment.partner_shipment_id,
+            shipment_name: shipment.name,
+          },
         );
+        let flags = [];
+
         _.forEach(shipment.flags, (shipFlag) => {
           const flag = _.find(shipmentFlag, { url: shipFlag });
           if (flag) {
             const alertType = flag.max_flag
               ? `max-${flag.type}`
               : `min-${flag.type}`;
-            _.forEach(shipmentAlerts, (shipAlert) => {
-              if (
-                shipAlert.alert_type === alertType
-                && _.includes(
-                  _.lowerCase(flag.name),
-                  _.lowerCase(shipAlert.parameter_type),
-                )
-                && !_.includes(viewedSensorAlerts, shipAlert.id)
-              ) {
-                let severity;
-                if (shipAlert.recovered_alert_id) {
-                  severity = 'success';
-                } else {
-                  severity = _.lowerCase(flag.type) === 'warning'
-                    ? 'warning'
-                    : 'error';
-                }
+            flags = [
+              ...flags,
+              {
+                ...flag,
+                alertType,
+              },
+            ];
+          }
+        });
 
-                alerts = [
-                  ...alerts,
-                  {
-                    name: shipAlert.recovered_alert_id
-                      ? `Recovered - ${flag.name}`
-                      : flag.name,
-                    shipment: shipment.name,
-                    id: shipAlert.id,
-                    severity,
-                    date_time: shipAlert.create_date,
-                  },
-                ];
-              }
-            });
+        _.forEach(shipmentAlerts, (alert) => {
+          if (alert.parameter_type === 'geofence') {
+            // const currentCustody = _.find(custodyRows, (custody) => (
+            //   custody.shipment_id === shipment.shipment_uuid
+            //   && custody.has_current_custody
+            //   && (
+            //     _.includes(
+            //       alert.current_custody_id,
+            //       custody.custodian_data.custodian_uuid,
+            //     )
+            //     || _.includes(
+            //       alert.current_custody_id,
+            //       custody.custody_uuid,
+            //     )
+            //   )
+            // ));
+            // if (
+            //   currentCustody !== undefined
+            //   && !_.includes(viewedAlerts, alert.id)
+            // ) {
+            //   let message = '';
+            //   switch (alert.shipment_custody_status) {
+            //     case 'present-start-geofence':
+            //       message = 'At start location';
+            //       break;
+
+            //     case 'left-start-geofence':
+            //       message = 'Left start location';
+            //       break;
+
+            //     case 'arriving-end-geofence':
+            //       message = 'Arriving end location';
+            //       break;
+
+            //     case 'present-end-geofence':
+            //       message = 'At end location';
+            //       break;
+
+            //     case 'reached-end-geofence':
+            //       message = 'Reached end location';
+            //       break;
+
+            //     case 'left-end-geofence':
+            //       message = 'Custody Handoff';
+            //       break;
+
+            //     default:
+            //       break;
+            //   }
+
+            //   alertsArray = [
+            //     ...alertsArray,
+            //     {
+            //       name: `${message} : ${
+            //         currentCustody.custodian_name
+            //       } -  Shipment ${shipment.name}`,
+            //       severity: 'info',
+            //       shipment: shipment.name,
+            //       id: alert.id,
+            //       date_time: alert.create_date,
+            //     },
+            //   ];
+            // }
+          } else {
+            const flag = _.find(flags, (flg) => (
+              alert.alert_type === flg.alertType
+              && _.includes(
+                _.lowerCase(flg.name),
+                _.lowerCase(alert.parameter_type),
+              )
+            ));
+            if (
+              flag
+              && !_.includes(viewedAlerts, alert.id)
+            ) {
+              const svrity = _.lowerCase(flag.type) === 'warning'
+                ? 'warning'
+                : 'error';
+
+              alertsArray = [
+                ...alertsArray,
+                {
+                  name: alert.recovered_alert_id
+                    ? `Recovered - ${
+                      flag.name
+                    } | Shipment: ${shipment.name}`
+                    : `${flag.name} | Shipment: ${shipment.name}`,
+                  severity: alert.recovered_alert_id
+                    ? 'success'
+                    : svrity,
+                  shipment: shipment.name,
+                  id: alert.id,
+                  date_time: alert.create_date,
+                },
+              ];
+            }
           }
         });
       });
 
-      if (alerts && alerts.length) {
-        setSenAlerts(alerts);
+      if (alertsArray && alertsArray.length) {
+        setAlerts(alertsArray);
       }
     }
   }, [shipmentData, shipmentFlag, sensorAlerts]);
 
-  useEffect(() => {
-    if (
-      shipmentData
-      && custodyData
-      && geofenceAlerts
-      && shipmentData.length > 0
-      && custodyData.length > 0
-      && geofenceAlerts.length > 0
-    ) {
-      let custodyRows = [];
-      let alerts = [];
-      let messages = [];
-      let currentCustody = {};
-      let updatedCustodies = [];
-      const viewedGeoAlerts = localStorage.getItem('geofenceAlerts')
-        ? JSON.parse(localStorage.getItem('geofenceAlerts'))
-        : [];
-
-      if (custodianData && custodianData.length) {
-        custodyRows = getFormattedCustodyRows(custodyData, custodianData);
-      }
-
-      _.forEach(shipmentData, (shipment) => {
-        _.forEach(geofenceAlerts, (alert, index) => {
-          if (
-            shipment.partner_shipment_id === alert.shipment_id
-            && alert.shipment_custody_status === 'left-start-geofence'
-          ) {
-            const custody = _.find(
-              custodyData,
-              { custody_uuid: alert.current_custody_id },
-            );
-            if (
-              custody
-              && custody.first_custody
-              && shipment.shipment_uuid === custody.shipment_id
-              && _.lowerCase(shipment.status) === 'planned'
-            ) {
-              dispatch(editShipment({
-                ...shipment,
-                status: 'Enroute',
-              }));
-            }
-          }
-
-          if (
-            shipment.partner_shipment_id === alert.shipment_id
-            && (
-              _.lowerCase(shipment.status) === 'planned'
-              || _.lowerCase(shipment.status) === 'enroute'
-            ) && alert.custodian_id
-            && alert.custodian_id.length
-          ) {
-            const sensorCustodian = alert.custodian_id;
-            if (custodyRows && custodyRows.length) {
-              _.forEach(custodyRows, (custody) => {
-                if (
-                  custody.shipment_id === shipment.shipment_uuid
-                  && (
-                    _.includes(
-                      sensorCustodian,
-                      custody.custodian_data.custodian_uuid,
-                    )
-                    || _.includes(
-                      sensorCustodian,
-                      custody.custody_uuid,
-                    )
-                  )
-                ) {
-                  if (custody.has_current_custody) {
-                    currentCustody = custody;
-                    currentCustody.custodian_uuid = custody.custodian_data.custodian_uuid;
-                  } else {
-                    updatedCustodies = [...updatedCustodies, custody];
-                  }
-                }
-              });
-            }
-
-            if (
-              currentCustody !== undefined
-              && (
-                _.includes(
-                  sensorCustodian,
-                  currentCustody.custodian_uuid,
-                )
-                || _.includes(
-                  sensorCustodian,
-                  currentCustody.custody_uuid,
-                )
-              )
-            ) {
-              let message = '';
-              switch (alert.shipment_custody_status) {
-                case 'present-start-geofence':
-                  message = 'At start location';
-                  break;
-
-                case 'left-start-geofence':
-                  message = 'Left start location';
-                  break;
-
-                case 'arriving-end-geofence':
-                  message = 'Arriving end location';
-                  break;
-
-                case 'present-end-geofence':
-                  message = 'At end location';
-                  break;
-
-                case 'reached-end-geofence':
-                  message = 'Reached end location';
-                  break;
-
-                case 'left-end-geofence':
-                  message = 'Custody Handoff';
-                  break;
-
-                default:
-                  break;
-              }
-
-              if (
-                !_.includes(viewedGeoAlerts, alert.id)
-                && moment().diff(alert.report_date_time, 'h') <= 24
-              ) {
-                alerts = [
-                  ...alerts,
-                  {
-                    name: `${message} : ${currentCustody.custodian_name} -  Shipment ${shipment.name}`,
-                    shipment: shipment.name,
-                    id: alert.id,
-                    date_time: alert.report_date_time,
-                  },
-                ];
-                messages = [
-                  ...messages,
-                  {
-                    type: 'geofence',
-                    shipment_uuid: shipment.name,
-                    alert_message: `Shipment ${message} of ${currentCustody.custodian_name}`,
-                    date_time: alert.report_date_time,
-                  },
-                ];
-
-                if (
-                  alert.shipment_custody_status === 'left-end-geofence'
-                  && currentCustody.custody_uuid !== alert.current_custody_id
-                ) {
-                  if (
-                    updatedCustodies
-                    && updatedCustodies.length
-                  ) {
-                    _.forEach(updatedCustodies, (custody) => {
-                      if (custody.custody_uuid === alert.current_custody_id) {
-                        // Update custody current one
-                        const custodyFormValues = {
-                          id: custody.id,
-                          has_current_custody: true,
-                        };
-                        dispatch(updateCustody(custodyFormValues));
-                      }
-                    });
-                  }
-
-                  const previousCustody = {
-                    id: currentCustody.id,
-                    has_current_custody: false,
-                  };
-                  dispatch(updateCustody(previousCustody));
-                }
-              }
-            }
-          }
-        });
-      });
-
-      alerts = _.orderBy(
-        alerts,
-        (item) => moment(item.date_time),
-        ['asc'],
-      );
-
-      if (alerts && alerts.length) {
-        setGeoAlerts(alerts);
-      }
-      if (messages.length > 0) {
-        dispatch(
-          emailAlerts({
-            organization_uuid,
-            messages,
-            date_time: moment().toJSON(),
-            subject_line: 'Geofence Alerts',
-          }),
-        );
-      }
-    }
-  }, [shipmentData, geofenceAlerts]);
-
-  const handleClose = (event, index, type) => {
+  const handleClose = (event, index) => {
     event.stopPropagation();
     event.preventDefault();
-    if (type === 'sensor') {
-      const open = _.filter(
-        senAlerts,
-        (item, idx) => (idx !== index),
-      );
-      const current = senAlerts[index];
 
-      let viewedSensorAlerts = localStorage.getItem('sensorAlerts')
-        ? JSON.parse(localStorage.getItem('sensorAlerts'))
-        : [];
-      viewedSensorAlerts = [...viewedSensorAlerts, current.id];
-      localStorage.setItem(
-        'sensorAlerts',
-        JSON.stringify(viewedSensorAlerts),
-      );
+    const open = _.filter(
+      alerts,
+      (item, idx) => (idx !== index),
+    );
+    const current = alerts[index];
 
-      setSenAlerts(open);
-    } else if (type === 'geofence') {
-      const open = _.filter(
-        geoAlerts,
-        (item, idx) => (idx !== index),
-      );
-      const current = geoAlerts[index];
+    let viewedAlerts = localStorage.getItem('viewedAlerts')
+      ? JSON.parse(localStorage.getItem('viewedAlerts'))
+      : [];
+    viewedAlerts = [...viewedAlerts, current.id];
+    localStorage.setItem(
+      'viewedAlerts',
+      JSON.stringify(viewedAlerts),
+    );
 
-      let viewedGeoAlerts = localStorage.getItem('geofenceAlerts')
-        ? JSON.parse(localStorage.getItem('geofenceAlerts'))
-        : [];
-      viewedGeoAlerts = [...viewedGeoAlerts, current.id];
-      localStorage.setItem('geofenceAlerts', JSON.stringify(viewedGeoAlerts));
-
-      setGeoAlerts(open);
-    }
+    setAlerts(open);
   };
 
   return (
     <div className={classes.root}>
-      {senAlerts
-      && senAlerts.length > 0
-      && _.map(senAlerts, (alert, index) => (
+      {alerts
+      && alerts.length > 0
+      && _.map(alerts, (alert, index) => (
         <Alert
           key={`sensorAlert${index}:${alert.shipment}`}
           variant="filled"
           severity={alert.severity}
-          onClose={(e) => handleClose(e, index, 'sensor')}
+          onClose={(e) => handleClose(e, index)}
           classes={{
             message: classes.message,
             root: classes.alert,
           }}
-          title={`${alert.name} | Shipment: ${
-            alert.shipment
-          } | ${moment(alert.date_time).fromNow()}`}
-        >
-          {`${alert.name} | Shipment: ${
-            alert.shipment
-          } | ${moment(alert.date_time).fromNow()}`}
-        </Alert>
-      ))}
-
-      {geoAlerts
-      && geoAlerts.length > 0
-      && _.map(geoAlerts, (alert, index) => (
-        <Alert
-          key={`geofenceAlert${index}:${alert.shipment}`}
-          variant="filled"
-          severity="info"
-          onClose={(e) => handleClose(e, index, 'geofence')}
-          classes={{
-            message: classes.message,
-            root: classes.alert,
-          }}
-          title={`${alert.name}`}
+          title={`${alert.name} | ${
+            moment(alert.date_time).fromNow()
+          }`}
         >
           {`${alert.name} | ${moment(alert.date_time).fromNow()}`}
         </Alert>

--- a/src/pages/Shipment/AlertInfo.js
+++ b/src/pages/Shipment/AlertInfo.js
@@ -78,10 +78,7 @@ const AlertInfo = ({
       _.forEach(shipmentData, (shipment) => {
         const shipmentAlerts = _.filter(
           sensorAlerts,
-          { 
-            shipment_id: shipment.partner_shipment_id,
-            shipment_name: shipment.name,
-          },
+          { shipment_id: shipment.partner_shipment_id },
         );
         let flags = [];
 
@@ -102,68 +99,61 @@ const AlertInfo = ({
         });
 
         _.forEach(shipmentAlerts, (alert) => {
-          if (alert.parameter_type === 'geofence') {
-            // const currentCustody = _.find(custodyRows, (custody) => (
-            //   custody.shipment_id === shipment.shipment_uuid
-            //   && custody.has_current_custody
-            //   && (
-            //     _.includes(
-            //       alert.current_custody_id,
-            //       custody.custodian_data.custodian_uuid,
-            //     )
-            //     || _.includes(
-            //       alert.current_custody_id,
-            //       custody.custody_uuid,
-            //     )
-            //   )
-            // ));
-            // if (
-            //   currentCustody !== undefined
-            //   && !_.includes(viewedAlerts, alert.id)
-            // ) {
-            //   let message = '';
-            //   switch (alert.shipment_custody_status) {
-            //     case 'present-start-geofence':
-            //       message = 'At start location';
-            //       break;
+          if (alert.parameter_type === 'location') {
+            const currentCustody = _.find(custodyRows, (custody) => (
+              custody.shipment_id === shipment.shipment_uuid
+              && _.includes(
+                alert.current_custody_id,
+                custody.custody_uuid,
+              )
+            ));
+            if (
+              currentCustody !== undefined
+              && !_.includes(viewedAlerts, alert.id)
+            ) {
+              let message = '';
+              switch (alert.alert_type) {
+                case 'present-start-geofence':
+                  message = 'At start location';
+                  break;
 
-            //     case 'left-start-geofence':
-            //       message = 'Left start location';
-            //       break;
+                case 'left-start-geofence':
+                  message = 'Left start location';
+                  break;
 
-            //     case 'arriving-end-geofence':
-            //       message = 'Arriving end location';
-            //       break;
+                case 'arriving-end-geofence':
+                  message = 'Arriving end location';
+                  break;
 
-            //     case 'present-end-geofence':
-            //       message = 'At end location';
-            //       break;
+                case 'present-end-geofence':
+                  message = 'At end location';
+                  break;
 
-            //     case 'reached-end-geofence':
-            //       message = 'Reached end location';
-            //       break;
+                case 'reached-end-geofence':
+                  message = 'Reached end location';
+                  break;
 
-            //     case 'left-end-geofence':
-            //       message = 'Custody Handoff';
-            //       break;
+                case 'left-end-geofence':
+                  message = 'Custody Handoff';
+                  break;
 
-            //     default:
-            //       break;
-            //   }
+                default:
+                  break;
+              }
 
-            //   alertsArray = [
-            //     ...alertsArray,
-            //     {
-            //       name: `${message} : ${
-            //         currentCustody.custodian_name
-            //       } -  Shipment ${shipment.name}`,
-            //       severity: 'info',
-            //       shipment: shipment.name,
-            //       id: alert.id,
-            //       date_time: alert.create_date,
-            //     },
-            //   ];
-            // }
+              alertsArray = [
+                ...alertsArray,
+                {
+                  name: `${message} : ${
+                    currentCustody.custodian_name
+                  } | Shipment ${shipment.name}`,
+                  severity: 'info',
+                  shipment: shipment.name,
+                  id: alert.id,
+                  date_time: alert.create_date,
+                },
+              ];
+            }
           } else {
             const flag = _.find(flags, (flg) => (
               alert.alert_type === flg.alertType

--- a/src/pages/Shipment/Shipment.js
+++ b/src/pages/Shipment/Shipment.js
@@ -113,7 +113,6 @@ const Shipment = (props) => {
     loading,
     shipmentOptions,
     custodyOptions,
-    geofenceAlerts,
     timezone,
     sensorAlerts,
   } = props;
@@ -141,9 +140,7 @@ const Shipment = (props) => {
 
   useEffect(() => {
     if (shipmentData === null) {
-      const getUpdatedSensorData = !aggregateReportData
-        || !geofenceAlerts
-        || !sensorAlerts;
+      const getUpdatedSensorData = !aggregateReportData || !sensorAlerts;
       dispatch(getShipmentDetails(
         organization,
         null,

--- a/src/redux/sensorsGateway/actions/sensorsGateway.actions.js
+++ b/src/redux/sensorsGateway/actions/sensorsGateway.actions.js
@@ -64,10 +64,6 @@ export const DELETE_SENSORS_TYPE = 'SENSORS/DELETE_SENSORS_TYPE';
 export const DELETE_SENSORS_TYPE_SUCCESS = 'SENSORS/DELETE_SENSORS_TYPE_SUCCESS';
 export const DELETE_SENSORS_TYPE_FAILURE = 'SENSORS/DELETE_SENSORS_TYPE_FAILURE';
 
-export const GET_GEOFENCE_ALERTS = 'SENSORS/GET_GEOFENCE_ALERTS';
-export const GET_GEOFENCE_ALERTS_SUCCESS = 'SENSORS/GET_GEOFENCE_ALERTS_SUCCESS';
-export const GET_GEOFENCE_ALERTS_FAILURE = 'SENSORS/GET_GEOFENCE_ALERTS_FAILURE';
-
 export const GET_AGGREGATE_REPORT = 'SENSORS/GET_AGGREGATE_REPORT';
 export const GET_AGGREGATE_REPORT_SUCCESS = 'SENSORS/GET_AGGREGATE_REPORT_SUCCESS';
 export const GET_AGGREGATE_REPORT_FAILURE = 'SENSORS/GET_AGGREGATE_REPORT_FAILURE';
@@ -235,15 +231,6 @@ export const editSensorType = (payload) => ({
 export const deleteSensorType = (id) => ({
   type: DELETE_SENSORS_TYPE,
   id,
-});
-
-/**
- * Get Sensor Report Alerts
- * @param {Array} partnerShipmentIds
- */
-export const getGeofenceAlerts = (partnerShipmentIds) => ({
-  type: GET_GEOFENCE_ALERTS,
-  partnerShipmentIds,
 });
 
 /**

--- a/src/redux/sensorsGateway/actions/sensorsGateway.actions.test.js
+++ b/src/redux/sensorsGateway/actions/sensorsGateway.actions.test.js
@@ -216,19 +216,6 @@ describe('Delete Sensor Type action', () => {
   });
 });
 
-// Test Get Geofence Alerts
-describe('Get Geofence Alerts action', () => {
-  it('should create an action to get geofence alerts', () => {
-    const partnerShipmentIds = ['1', '2', '3'];
-    const expectedAction = {
-      type: actions.GET_GEOFENCE_ALERTS,
-      partnerShipmentIds,
-    };
-    expect(actions.getGeofenceAlerts(partnerShipmentIds))
-      .toEqual(expectedAction);
-  });
-});
-
 // Test Get Aggregate Report
 describe('Get Aggregate Report action', () => {
   it('should create an action to get aggregate report', () => {

--- a/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.js
+++ b/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.js
@@ -48,9 +48,6 @@ import {
   DELETE_SENSORS_TYPE,
   DELETE_SENSORS_TYPE_SUCCESS,
   DELETE_SENSORS_TYPE_FAILURE,
-  GET_GEOFENCE_ALERTS,
-  GET_GEOFENCE_ALERTS_SUCCESS,
-  GET_GEOFENCE_ALERTS_FAILURE,
   GET_AGGREGATE_REPORT,
   GET_AGGREGATE_REPORT_SUCCESS,
   GET_AGGREGATE_REPORT_FAILURE,
@@ -67,7 +64,6 @@ const initialState = {
   gatewayTypeList: null,
   sensorData: null,
   sensorTypeList: null,
-  geofenceAlerts: null,
   aggregateReportData: null,
   sensorAlerts: null,
   allAlerts: null,
@@ -481,30 +477,6 @@ export default (state = initialState, action) => {
       };
 
     case DELETE_SENSORS_TYPE_FAILURE:
-      return {
-        ...state,
-        loading: false,
-        loaded: true,
-        error: action.error,
-      };
-
-    case GET_GEOFENCE_ALERTS:
-      return {
-        ...state,
-        loading: true,
-        loaded: false,
-        error: null,
-      };
-
-    case GET_GEOFENCE_ALERTS_SUCCESS:
-      return {
-        ...state,
-        loading: false,
-        loaded: true,
-        geofenceAlerts: action.data,
-      };
-
-    case GET_GEOFENCE_ALERTS_FAILURE:
       return {
         ...state,
         loading: false,

--- a/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.test.js
+++ b/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.test.js
@@ -9,7 +9,6 @@ const initialState = {
   gatewayTypeList: null,
   sensorData: null,
   sensorTypeList: null,
-  geofenceAlerts: null,
   aggregateReportData: null,
   sensorAlerts: null,
   allAlerts: null,
@@ -594,42 +593,6 @@ describe('Delete Sensor type reducer', () => {
     expect(reducer.default(
       initialState,
       { type: actions.DELETE_SENSORS_TYPE_FAILURE },
-    )).toEqual({
-      ...initialState,
-      error: undefined,
-      loaded: true,
-      loading: false,
-    });
-  });
-});
-
-describe('Get Geofence Alerts reducer', () => {
-  it('Empty Reducer', () => {
-    expect(reducer.default(
-      initialState,
-      { type: actions.GET_GEOFENCE_ALERTS },
-    )).toEqual({
-      ...initialState,
-      loading: true,
-    });
-  });
-
-  it('Get Geofence Alerts success Reducer', () => {
-    expect(reducer.default(
-      initialState,
-      { type: actions.GET_GEOFENCE_ALERTS_SUCCESS },
-    )).toEqual({
-      ...initialState,
-      loaded: true,
-      loading: false,
-      geofenceAlerts: undefined,
-    });
-  });
-
-  it('Get Geofence Alerts fail Reducer', () => {
-    expect(reducer.default(
-      initialState,
-      { type: actions.GET_GEOFENCE_ALERTS_FAILURE },
     )).toEqual({
       ...initialState,
       error: undefined,

--- a/src/redux/sensorsGateway/sagas/sensorsGateway.saga.js
+++ b/src/redux/sensorsGateway/sagas/sensorsGateway.saga.js
@@ -49,9 +49,6 @@ import {
   DELETE_SENSORS_TYPE,
   DELETE_SENSORS_TYPE_SUCCESS,
   DELETE_SENSORS_TYPE_FAILURE,
-  GET_GEOFENCE_ALERTS,
-  GET_GEOFENCE_ALERTS_SUCCESS,
-  GET_GEOFENCE_ALERTS_FAILURE,
   GET_AGGREGATE_REPORT,
   GET_AGGREGATE_REPORT_SUCCESS,
   GET_AGGREGATE_REPORT_FAILURE,
@@ -656,33 +653,6 @@ function* deleteSensorType(payload) {
   }
 }
 
-function* getGeofenceAlerts(payload) {
-  try {
-    const data = yield call(
-      httpService.makeRequest,
-      'get',
-      `${environment.API_URL}${sensorApiEndPoint}sensor_report/?shipment_id=${payload.partnerShipmentIds}&shipment_custody_status=present-start-geofence,left-start-geofence,arriving-end-geofence,present-end-geofence,reached-end-geofence,left-end-geofence`,
-      null,
-      true,
-    );
-    yield put({ type: GET_GEOFENCE_ALERTS_SUCCESS, data: data.data });
-  } catch (error) {
-    yield [
-      yield put(
-        showAlert({
-          type: 'error',
-          open: true,
-          message: 'Couldn\'t load data due to some error!',
-        }),
-      ),
-      yield put({
-        type: GET_GEOFENCE_ALERTS_FAILURE,
-        error,
-      }),
-    ];
-  }
-}
-
 function* getAggregateReportList(payload) {
   try {
     const data = yield call(
@@ -818,10 +788,6 @@ function* watchDeleteSensorType() {
   yield takeLatest(DELETE_SENSORS_TYPE, deleteSensorType);
 }
 
-function* watchGetGeofenceAlerts() {
-  yield takeLatest(GET_GEOFENCE_ALERTS, getGeofenceAlerts);
-}
-
 function* watchGetAggregateReport() {
   yield takeLatest(GET_AGGREGATE_REPORT, getAggregateReportList);
 }
@@ -848,7 +814,6 @@ export default function* sensorsGatewaySaga() {
     watchAddSensorType(),
     watchEditSensorType(),
     watchDeleteSensorType(),
-    watchGetGeofenceAlerts(),
     watchGetAggregateReport(),
     watchGetSensorAlerts(),
   ]);

--- a/src/redux/shipment/actions/shipment.actions.js
+++ b/src/redux/shipment/actions/shipment.actions.js
@@ -36,8 +36,6 @@ export const GET_DASHBOARD_ITEMS = 'SHIPMENT/GET_DASHBOARD_ITEMS';
 export const GET_DASHBOARD_ITEMS_SUCCESS = 'SHIPMENT/GET_DASHBOARD_ITEMS_SUCCESS';
 export const GET_DASHBOARD_ITEMS_FAILURE = 'SHIPMENT/GET_DASHBOARD_ITEMS_FAILURE';
 
-export const EMAIL_ALERTS = 'SHIPMENT/EMAIL_ALERTS';
-
 export const ADD_PDF_IDENTIFIER = 'SHIPMENT/ADD_PDF_IDENTIFIER';
 export const ADD_PDF_IDENTIFIER_SUCCESS = 'SHIPMENT/ADD_PDF_IDENTIFIER_SUCCESS';
 export const ADD_PDF_IDENTIFIER_FAILURE = 'SHIPMENT/ADD_PDF_IDENTIFIER_FAILURE';
@@ -162,15 +160,6 @@ export const deleteShipmentFlag = (id) => ({
 export const getDashboardItems = (organization_uuid) => ({
   type: GET_DASHBOARD_ITEMS,
   organization_uuid,
-});
-
-/**
- * Email Alerts
- * @param {Object} alerts
- */
-export const emailAlerts = (alerts) => ({
-  type: EMAIL_ALERTS,
-  alerts,
 });
 
 /**

--- a/src/redux/shipment/actions/shipment.actions.test.js
+++ b/src/redux/shipment/actions/shipment.actions.test.js
@@ -154,19 +154,6 @@ describe('Get DashBoard Items action', () => {
   });
 });
 
-// Test Email Alerts action
-describe('Email Alerts action', () => {
-  it('should create an action to email alerts', () => {
-    const alerts = { message: 'Alert message' };
-    const expectedAction = {
-      type: actions.EMAIL_ALERTS,
-      alerts,
-    };
-    expect(actions.emailAlerts(alerts))
-      .toEqual(expectedAction);
-  });
-});
-
 // Test Add PDF Identifier action
 describe('Add PDF Identifier action', () => {
   it('should create an action to add PDF identifier', () => {

--- a/src/redux/shipment/sagas/shipment.saga.js
+++ b/src/redux/shipment/sagas/shipment.saga.js
@@ -7,7 +7,6 @@ import { environment } from '@environments/environment';
 import { showAlert } from '@redux/alert/actions/alert.actions';
 import {
   getAggregateReport,
-  getGeofenceAlerts,
   getSensorAlerts,
 } from '@redux/sensorsGateway/actions/sensorsGateway.actions';
 import { routes } from '@routes/routesConstants';
@@ -39,7 +38,6 @@ import {
   GET_DASHBOARD_ITEMS,
   GET_DASHBOARD_ITEMS_SUCCESS,
   GET_DASHBOARD_ITEMS_FAILURE,
-  EMAIL_ALERTS,
   ADD_PDF_IDENTIFIER,
   ADD_PDF_IDENTIFIER_SUCCESS,
   ADD_PDF_IDENTIFIER_FAILURE,
@@ -76,7 +74,6 @@ function* getShipmentList(payload) {
       if (payload.getUpdatedSensorData) {
         yield [
           yield put(getAggregateReport(encodedIds)),
-          yield put(getGeofenceAlerts(encodedIds)),
           yield put(getSensorAlerts(encodedIds, 24)),
         ];
       }
@@ -418,32 +415,6 @@ function* getDashboard(payload) {
   }
 }
 
-function* sendEmailAlerts(payload) {
-  try {
-    const alerts = yield call(
-      httpService.makeRequest,
-      'post',
-      `${environment.API_URL}coreuser/alert/`,
-      payload.alerts,
-    );
-    yield put(
-      showAlert({
-        type: 'info',
-        open: true,
-        message: 'Email alerts sent successfully',
-      }),
-    );
-  } catch (error) {
-    yield put(
-      showAlert({
-        type: 'error',
-        open: true,
-        message: 'Couldn\'t send email alerts due to some error!',
-      }),
-    );
-  }
-}
-
 function* pdfIdentifier(action) {
   const {
     data,
@@ -553,10 +524,6 @@ function* watchGetDashboardItems() {
   yield takeLatest(GET_DASHBOARD_ITEMS, getDashboard);
 }
 
-function* watchEmailAlerts() {
-  yield takeLatest(EMAIL_ALERTS, sendEmailAlerts);
-}
-
 function* watchPdfIdentifier() {
   yield takeLatest(ADD_PDF_IDENTIFIER, pdfIdentifier);
 }
@@ -572,7 +539,6 @@ export default function* shipmentSaga() {
     watchEditShipmentFlag(),
     watchDeleteShipmentFlag(),
     watchGetDashboardItems(),
-    watchEmailAlerts(),
     watchPdfIdentifier(),
   ]);
 }


### PR DESCRIPTION
## Purpose
Move geofence alerts from FE to BE

## Further info
* Remove email trigger for geofence alerts.
* Remove update custody status for geofence alerts.
* Merge Sensor and GeoFence Alerts.
* Fetch fresh data for shipment, custody, alerts on Shipment, Reporting, etc pages.