### PR TITLE
Remove Temperature conversion

### DIFF
--- a/src/pages/Reporting/ReportingConstants.js
+++ b/src/pages/Reporting/ReportingConstants.js
@@ -16,9 +16,6 @@ import {
 import {
   getFormattedCustodyRows,
 } from '@pages/Shipment/ShipmentConstants';
-import {
-  convertUnitsOfMeasure,
-} from '@utils/utilMethods';
 
 export const SHIPMENT_OVERVIEW_TOOL_TIP = 'Select a shipment to view reporting data';
 
@@ -200,15 +197,7 @@ export const getShipmentOverview = (
           }
           _.forEach(report.report_entries, (report_entry) => {
             try {
-              const temperature = editedShipment.platform_name === 'tive'
-                ? report_entry.report_temp
-                : convertUnitsOfMeasure(
-                  'celsius',
-                  report_entry.report_temp,
-                  temperatureUnit,
-                  'temperature',
-                );
-
+              const temperature = report_entry.report_temp;
               let dateTime = '';
               if ('report_timestamp' in report_entry) {
                 if (report_entry.report_timestamp !== null) {

--- a/src/pages/Shipment/Shipment.js
+++ b/src/pages/Shipment/Shipment.js
@@ -48,7 +48,6 @@ import {
   getSensorType,
   getSensorAlerts,
 } from '@redux/sensorsGateway/actions/sensorsGateway.actions';
-import { convertUnitsOfMeasure } from '@utils/utilMethods';
 import {
   getShipmentDetails,
   deleteShipment,
@@ -251,15 +250,7 @@ const Shipment = (props) => {
           }
           _.forEach(report.report_entries, (report_entry) => {
             try {
-              const temperature = selectedShipment.platform_name === 'tive'
-                ? report_entry.report_temp
-                : convertUnitsOfMeasure(
-                  'celsius',
-                  report_entry.report_temp,
-                  temperatureUnit,
-                  'temperature',
-                );
-
+              const temperature = report_entry.report_temp;
               let dateTime;
               if ('report_timestamp' in report_entry) {
                 if (report_entry.report_timestamp !== null) {

--- a/src/utils/utilMethods.js
+++ b/src/utils/utilMethods.js
@@ -62,21 +62,6 @@ export const convertUnitsOfMeasure = (
 ) => {
   let returnValue = null;
   switch (_class) {
-    case 'temperature':
-      if (
-        sourceUnit === 'fahrenheit'
-        && destinationUnit === 'celsius'
-      ) {
-        returnValue = (((value - 32) * 5) / 9).toFixed(2);
-      }
-      if (
-        sourceUnit === 'celsius'
-        && destinationUnit === 'fahrenheit'
-      ) {
-        returnValue = ((value * 9) / 5 + 32).toFixed(2);
-      }
-      break;
-
     case 'distance':
       if (
         sourceUnit === 'km'


### PR DESCRIPTION
## Purpose
Remove Temperature Conversion

## Further info
Remove temperature conversion (from Celsius to Fahrenheit) for platforms from FE and move to BE.