### PR TITLE
Temperature changes, Pull new gateways on refresh, Remove distance conversion

### DIFF
--- a/src/components/MapComponent/MapComponent.js
+++ b/src/components/MapComponent/MapComponent.js
@@ -14,7 +14,6 @@ import {
   REPORT_TYPES,
   getIcon,
 } from '@pages/Reporting/ReportingConstants';
-import { convertUnitsOfMeasure } from '@utils/utilMethods';
 
 export const MapComponent = (props) => {
   const { markers, setSelectedMarker, geofence } = props;
@@ -244,12 +243,7 @@ const RenderedMap = withScriptjs(
             />
             <InfoWindow>
               <div style={{ color: 'black' }}>
-                {`Geofence of ${convertUnitsOfMeasure(
-                  'km',
-                  parseFloat(mark.radius),
-                  'miles',
-                  'distance',
-                )} miles`}
+                {`Geofence of ${mark.radius} miles`}
               </div>
             </InfoWindow>
           </Marker>

--- a/src/layout/TopBar/TopBar.js
+++ b/src/layout/TopBar/TopBar.js
@@ -27,6 +27,9 @@ import {
   getOrganizationOptions,
   setTimezone,
 } from '@redux/options/actions/options.actions';
+import {
+  getNewGateways,
+} from '@redux/sensorsGateway/actions/sensorsGateway.actions';
 import { routes } from '@routes/routesConstants';
 import {
   checkForAdmin,
@@ -104,7 +107,7 @@ const TopBar = ({
   };
 
   const refreshPage = () => {
-    window.location.reload();
+    dispatch(getNewGateways());
   };
 
   const handleLogoutClick = () => {

--- a/src/pages/AdminPanel/Configuration/components/OrganizationSettings.js
+++ b/src/pages/AdminPanel/Configuration/components/OrganizationSettings.js
@@ -14,7 +14,6 @@ import Loader from '@components/Loader/Loader';
 import {
   updateOrganization,
 } from '@redux/authuser/actions/authuser.actions';
-import { convertUnitsOfMeasure } from '@utils/utilMethods';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -87,12 +86,7 @@ const OrganizationSettings = ({
 
   const resetValues = () => {
     setAllowImportExport(organizationData.allow_import_export);
-    setRadius(convertUnitsOfMeasure(
-      'km',
-      parseFloat(organizationData.radius),
-      'miles',
-      'distance',
-    ));
+    setRadius(organizationData.radius);
     setOrgType(organizationData.organization_type || '');
   };
 
@@ -106,14 +100,7 @@ const OrganizationSettings = ({
       ...organizationData,
       edit_date: new Date(),
       allow_import_export: allowImportExport,
-      radius: radius
-        ? convertUnitsOfMeasure(
-          'miles',
-          parseFloat(radius),
-          'km',
-          'distance',
-        )
-        : 0,
+      radius: radius || 0,
       organization_type: orgType,
     };
     dispatch(updateOrganization(data));

--- a/src/pages/Shipment/components/EnvironmentalLimitsInfo.js
+++ b/src/pages/Shipment/components/EnvironmentalLimitsInfo.js
@@ -278,7 +278,7 @@ const EnvironmentalLimitsInfo = ({
               className={classes.boxHeading}
               variant="body2"
             >
-              Temperature settings
+              Temperature settings (°F)
             </Typography>
             <CardContent>
               <Grid container spacing={2}>
@@ -401,11 +401,11 @@ const EnvironmentalLimitsInfo = ({
                     marks={[
                       {
                         value: 0,
-                        label: '0°',
+                        label: '0°F',
                       },
                       {
                         value: 100,
-                        label: '100°',
+                        label: '100°F',
                       },
                     ]}
                   />

--- a/src/redux/sensorsGateway/actions/sensorsGateway.actions.js
+++ b/src/redux/sensorsGateway/actions/sensorsGateway.actions.js
@@ -3,6 +3,10 @@ export const GET_GATEWAYS = 'SENSORS/GET_GATEWAYS';
 export const GET_GATEWAYS_SUCCESS = 'SENSORS/GET_GATEWAYS_SUCCESS';
 export const GET_GATEWAYS_FAILURE = 'SENSORS/GET_GATEWAYS_FAILURE';
 
+export const GET_NEW_GATEWAYS = 'SENSORS/GET_NEW_GATEWAYS';
+export const GET_NEW_GATEWAYS_SUCCESS = 'SENSORS/GET_NEW_GATEWAYS_SUCCESS';
+export const GET_NEW_GATEWAYS_FAILURE = 'SENSORS/GET_NEW_GATEWAYS_FAILURE';
+
 export const ADD_GATEWAY = 'SENSORS/ADD_GATEWAY';
 export const ADD_GATEWAY_SUCCESS = 'SENSORS/ADD_GATEWAY_SUCCESS';
 export const ADD_GATEWAY_FAILURE = 'SENSORS/ADD_GATEWAY_FAILURE';
@@ -79,6 +83,13 @@ export const GET_SENSOR_ALERTS_FAILURE = 'SENSORS/GET_SENSOR_ALERTS_FAILURE';
 export const getGateways = (organization_uuid) => ({
   type: GET_GATEWAYS,
   organization_uuid,
+});
+
+/**
+ *  Get New Gateways
+ */
+export const getNewGateways = () => ({
+  type: GET_NEW_GATEWAYS,
 });
 
 /**

--- a/src/redux/sensorsGateway/actions/sensorsGateway.actions.test.js
+++ b/src/redux/sensorsGateway/actions/sensorsGateway.actions.test.js
@@ -13,6 +13,16 @@ describe('Get Gateways action', () => {
   });
 });
 
+// Test Get New Gateways
+describe('Get New Gateways action', () => {
+  it('should create an action to get new Gateways', () => {
+    const expectedAction = {
+      type: actions.GET_NEW_GATEWAYS,
+    };
+    expect(actions.getNewGateways()).toEqual(expectedAction);
+  });
+});
+
 // Test Add Gateway
 describe('Add Gateway action', () => {
   it('should create an action to add Gateway', () => {

--- a/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.js
+++ b/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.js
@@ -3,6 +3,9 @@ import {
   GET_GATEWAYS,
   GET_GATEWAYS_SUCCESS,
   GET_GATEWAYS_FAILURE,
+  GET_NEW_GATEWAYS,
+  GET_NEW_GATEWAYS_SUCCESS,
+  GET_NEW_GATEWAYS_FAILURE,
   ADD_GATEWAY,
   ADD_GATEWAY_SUCCESS,
   ADD_GATEWAY_FAILURE,
@@ -111,6 +114,29 @@ export default (state = initialState, action) => {
       };
 
     case GET_GATEWAYS_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        error: action.error,
+      };
+
+    case GET_NEW_GATEWAYS:
+      return {
+        ...state,
+        loading: true,
+        loaded: false,
+        error: null,
+      };
+
+    case GET_NEW_GATEWAYS_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+      };
+
+    case GET_NEW_GATEWAYS_FAILURE:
       return {
         ...state,
         loading: false,

--- a/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.test.js
+++ b/src/redux/sensorsGateway/reducers/sensorsGateway.reducer.test.js
@@ -50,6 +50,41 @@ describe('Get Gateway reducer', () => {
   });
 });
 
+describe('Get New Gateways reducer', () => {
+  it('Empty Reducer', () => {
+    expect(reducer.default(
+      initialState,
+      { type: actions.GET_NEW_GATEWAYS },
+    )).toEqual({
+      ...initialState,
+      loading: true,
+    });
+  });
+
+  it('get new Gateways success Reducer', () => {
+    expect(reducer.default(
+      initialState,
+      { type: actions.GET_NEW_GATEWAYS_SUCCESS },
+    )).toEqual({
+      ...initialState,
+      loaded: true,
+      loading: false,
+    });
+  });
+
+  it('get new Gateways fail Reducer', () => {
+    expect(reducer.default(
+      initialState,
+      { type: actions.GET_NEW_GATEWAYS_FAILURE },
+    )).toEqual({
+      ...initialState,
+      error: undefined,
+      loaded: true,
+      loading: false,
+    });
+  });
+});
+
 describe('Add Gateway reducer', () => {
   it('Empty reducer', () => {
     expect(reducer.default(

--- a/src/redux/sensorsGateway/sagas/sensorsGateway.saga.js
+++ b/src/redux/sensorsGateway/sagas/sensorsGateway.saga.js
@@ -8,6 +8,9 @@ import {
   GET_GATEWAYS,
   GET_GATEWAYS_SUCCESS,
   GET_GATEWAYS_FAILURE,
+  GET_NEW_GATEWAYS,
+  GET_NEW_GATEWAYS_SUCCESS,
+  GET_NEW_GATEWAYS_FAILURE,
   ADD_GATEWAY,
   ADD_GATEWAY_FAILURE,
   EDIT_GATEWAY,
@@ -80,6 +83,32 @@ function* getGatewayList(payload) {
       ),
       yield put({
         type: GET_GATEWAYS_FAILURE,
+        error,
+      }),
+    ];
+  }
+}
+
+function* getNewGateways(payload) {
+  try {
+    const data = yield call(
+      httpService.makeRequest,
+      'get',
+      `${environment.API_URL}${sensorApiEndPoint}gateway/create_gateway/`,
+    );
+    yield put({ type: GET_NEW_GATEWAYS_SUCCESS });
+    window.location.reload();
+  } catch (error) {
+    yield [
+      yield put(
+        showAlert({
+          type: 'error',
+          open: true,
+          message: 'Couldn\'t load new gateways due to some error!',
+        }),
+      ),
+      yield put({
+        type: GET_NEW_GATEWAYS_FAILURE,
         error,
       }),
     ];
@@ -728,6 +757,10 @@ function* watchGetGateway() {
   yield takeLatest(GET_GATEWAYS, getGatewayList);
 }
 
+function* watchGetNewGateways() {
+  yield takeLatest(GET_NEW_GATEWAYS, getNewGateways);
+}
+
 function* watchAddGateway() {
   yield takeLatest(ADD_GATEWAY, addGateway);
 }
@@ -799,6 +832,7 @@ function* watchGetSensorAlerts() {
 export default function* sensorsGatewaySaga() {
   yield all([
     watchGetGateway(),
+    watchGetNewGateways(),
     watchAddGateway(),
     watchDeleteGateway(),
     watchEditGateway(),

--- a/src/utils/utilMethods.js
+++ b/src/utils/utilMethods.js
@@ -46,39 +46,3 @@ export const setOptionsData = (options, fieldName) => {
   }
   return result;
 };
-
-/**
- * Used to convert value measured from one unit to other
- * @param {String} sourceUnit
- * @param {Number} value
- * @param {String} destinationUnit
- * @param {String} _class
- */
-export const convertUnitsOfMeasure = (
-  sourceUnit,
-  value,
-  destinationUnit,
-  _class,
-) => {
-  let returnValue = null;
-  switch (_class) {
-    case 'distance':
-      if (
-        sourceUnit === 'km'
-        && destinationUnit === 'miles'
-      ) {
-        returnValue = (value * 0.6214).toFixed(2);
-      }
-      if (
-        sourceUnit === 'miles'
-        && destinationUnit === 'km'
-      ) {
-        returnValue = (value / 0.6214).toFixed(2);
-      }
-      break;
-
-    default:
-      break;
-  }
-  return returnValue;
-};


### PR DESCRIPTION
## Purpose
Temperature unit change. Pull new gateways. Remove distance conversion.

## Further info
* Change temperature from Celsius to Fahrenheit.
* On data refresh, pull in new gateways (if any).
* Remove distance conversion from miles and/or km.