### PR TITLE
Hotfix for edit shipment

### DIFF
--- a/src/pages/Shipment/components/ShipmentDataTable.js
+++ b/src/pages/Shipment/components/ShipmentDataTable.js
@@ -170,7 +170,7 @@ const ShipmentDataTable = ({
       const restCols = _.filter(cols, (col) => col.name !== 'Copy');
       setColumns(restCols);
     }
-  }, [timezone, consortiumData, rowsType]);
+  }, [timezone, consortiumData, rowsType, rows]);
 
   return (
     <div className={classes.root}>


### PR DESCRIPTION
## Purpose
Hotfix for edit shipment issue

## Further info
Edit action not working on initial data load since rows were empty. Reload column edit action once rows are updated/changed.