### PR TITLE
Update custodian info as soon as edited

### DIFF
--- a/src/pages/Shipment/components/Sensors&GatewayInfo.js
+++ b/src/pages/Shipment/components/Sensors&GatewayInfo.js
@@ -172,7 +172,13 @@ const SensorsGatewayInfo = ({
   const submitDisabled = () => !gatewayIds.length || gatewayData === null;
 
   // eslint-disable-next-line max-len
-  checkIfSensorGatewayEdited = () => !!(gatewayIds.length !== shipmentFormData.gateway_ids.length);
+  checkIfSensorGatewayEdited = () => {
+    if (gatewayIds.length) {
+      return shipmentFormData.gateway_ids ?
+       !!(gatewayIds.length !== shipmentFormData.gateway_ids.length) : true;
+    }
+    return false;
+  };
 
   /**
    * Submit The form and add/edit custodian

--- a/src/pages/Shipment/components/ShipmentInfo.js
+++ b/src/pages/Shipment/components/ShipmentInfo.js
@@ -150,7 +150,7 @@ const ShipmentInfo = (props) => {
   const organization = useContext(UserContext).organization.organization_uuid;
 
   useEffect(() => {
-    if (editPage && shipmentFormData === null) {
+    if (editPage) {
       dispatch(saveShipmentFormData(editData));
     }
   }, []);

--- a/src/redux/shipment/sagas/shipment.saga.js
+++ b/src/redux/shipment/sagas/shipment.saga.js
@@ -68,23 +68,27 @@ function* getShipmentList(payload) {
         shipmentAction: payload.shipmentAction,
         status: payload.status ? payload.status : 'All',
       });
-      let UUIDS = '';
+      let uuids = '';
       if (data.data instanceof Array) {
-        UUIDS = _.map(data.data, 'shipment_uuid');
+        const UUIDS = _.map(data.data, 'shipment_uuid');
+        uuids = _.toString(_.without(UUIDS, null));
+      } else {
+        uuids = data.data.shipment_uuid;
+      }
+      if (payload.id && data.data instanceof Array) {
         yield put(
           saveShipmentFormData(
             data.data.find((shipment) => shipment.id === payload.id),
           ),
         );
-      } else {
-        UUIDS = data.data.shipment_uuid;
+
+      } else if (data.data instanceof Object) {
         yield put(
           saveShipmentFormData(
             data.data,
           ),
         );
       }
-      const uuids = _.toString(_.without(UUIDS, null));
       const encodedUUIDs = encodeURIComponent(uuids);
       if (payload.getUpdatedCustody && encodedUUIDs) {
         yield [


### PR DESCRIPTION
## Purpose
_Update custodian info as soon as edited_
_Remove the need to refresh when updating data_
_Fixed issue in modal popup for gateways_

## Further info
_ When creating a new shipment, not able to add a custodian. Although when trying to add a custodian during shipment creation, everything seems to go fine but the custodian is not listed - it shows it as blank and the custodians are not listed under 'Custodian Name' column.
 It looks like when first setting up the shipment, it doesn't display custodians being added. However, after finishing up the sequence and then refresh the screen then it shows the custodians. When one changes shipment status to 'Cancelled' the custodian list disappears again until the screen is refreshed.
_

## Ticket number
_#267_

closing #267 

