### PR TITLE
Zendesk widget integration and update gateway when shipment canceled or completed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,9 @@
 <body>
     <div id="root"></div>
     <script type="text/javascript" src="/environment.js"></script>
+    <!-- Start of transparentpath Zendesk Widget script -->
+    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=2dd78851-7c96-4be1-a858-c68b7a824262"> </script>
+    <!-- End of transparentpath Zendesk Widget script -->
 </body>
 
 </html>

--- a/src/modules/http/http.service.js
+++ b/src/modules/http/http.service.js
@@ -25,7 +25,7 @@ function makeRequest(method, url, body, useJwt, contentType, responseType, reque
     Authorization: `${tokenType} ${token}`,
     // 'Content-Type': contentType || 'application/json', // Commenting to make it work for GCP
   };
-  if (method === 'POST' || method === 'post') {
+  if (method !== 'GET' && method !== 'get' && method !== 'OPTIONS' && method !== 'options') {
     headers['Content-Type'] = 'application/json';
   }
   if (requestHeader) {

--- a/src/pages/Shipment/components/ShipmentInfo.js
+++ b/src/pages/Shipment/components/ShipmentInfo.js
@@ -25,6 +25,9 @@ import {
   addShipment,
   saveShipmentFormData,
 } from '@redux/shipment/actions/shipment.actions';
+import {
+  getGateways,
+} from '@redux/sensorsGateway/actions/sensorsGateway.actions';
 import { routes } from '@routes/routesConstants';
 import {
   SHIPMENT_STATUS,
@@ -86,6 +89,7 @@ const ShipmentInfo = (props) => {
     setConfirmModal,
     setConfirmModalFor,
     timezone,
+    gatewayData,
   } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -304,14 +308,21 @@ const ShipmentInfo = (props) => {
     };
 
     if (editPage && editData) {
-      dispatch(
-        editShipment(
-          shipmentFormValue,
-          history,
-          `${routes.SHIPMENT}/edit/:${editData.id}`,
-          organization,
-        ),
-      );
+      if (shipmentFormData.gateway_ids.length > 0) {
+        let attachedGateway = null;
+        attachedGateway = _.filter(
+          gatewayData, (gateway) => gateway.gateway_uuid === shipmentFormData.gateway_ids[0],
+        );
+        dispatch(
+          editShipment(
+            shipmentFormValue,
+            history,
+            `${routes.SHIPMENT}/edit/:${editData.id}`,
+            organization,
+            attachedGateway[0],
+          ),
+        );
+      }
     } else {
       dispatch(addShipment(shipmentFormValue, history, null, organization));
     }
@@ -777,11 +788,13 @@ const mapStateToProps = (state, ownProps) => ({
   ...state.itemsReducer,
   ...state.custodianReducer,
   ...state.optionsReducer,
+  ...state.sensorsGatewayReducer,
   loading: (
     state.shipmentReducer.loading
     || state.itemsReducer.loading
     || state.custodianReducer.loading
     || state.optionsReducer.loading
+    || state.sensorsGatewayReducer.loading
   ),
 });
 

--- a/src/redux/shipment/actions/shipment.actions.js
+++ b/src/redux/shipment/actions/shipment.actions.js
@@ -85,18 +85,21 @@ export const addShipment = (
  * @param {Object} history
  * @param {String} redirectTo path to redirect
  * @param {String} organization_uuid
+ * @param {String} gateway_id
  */
 export const editShipment = (
   payload,
   history,
   redirectTo,
   organization_uuid,
+  gateway,
 ) => ({
   type: EDIT_SHIPMENT,
   payload,
   history,
   redirectTo,
   organization_uuid,
+  gateway,
 });
 
 /**

--- a/src/redux/shipment/actions/shipment.actions.test.js
+++ b/src/redux/shipment/actions/shipment.actions.test.js
@@ -61,18 +61,21 @@ describe('Edit Shipment action', () => {
     const history = {};
     const redirectTo = '/test';
     const organization_uuid = 'gweiug-3t2igf-3yfhf-329hgds73';
+    const gateway = { id: 11 };
     const expectedAction = {
       type: actions.EDIT_SHIPMENT,
       payload,
       history,
       redirectTo,
       organization_uuid,
+      gateway,
     };
     expect(actions.editShipment(
       payload,
       history,
       redirectTo,
       organization_uuid,
+      gateway,
     )).toEqual(expectedAction);
   });
 });

--- a/src/redux/shipment/sagas/shipment.saga.js
+++ b/src/redux/shipment/sagas/shipment.saga.js
@@ -6,6 +6,7 @@ import { httpService } from '@modules/http/http.service';
 import { showAlert } from '@redux/alert/actions/alert.actions';
 import {
   getAggregateReport,
+  editGateway,
 } from '@redux/sensorsGateway/actions/sensorsGateway.actions';
 import {
   getCustody,
@@ -30,7 +31,7 @@ import {
   ADD_PDF_IDENTIFIER_SUCCESS,
   ADD_PDF_IDENTIFIER_FAILURE,
 } from '../actions/shipment.actions';
-import { GET_AGGREGATE_REPORT_SUCCESS } from '../../sensorsGateway/actions/sensorsGateway.actions';
+import { GET_AGGREGATE_REPORT_SUCCESS, EDIT_GATEWAY_SUCCESS } from '../../sensorsGateway/actions/sensorsGateway.actions';
 import { GET_CUSTODY_SUCCESS } from '../../custodian/actions/custodian.actions';
 
 const shipmentApiEndPoint = 'shipment/';
@@ -189,7 +190,9 @@ function* addShipment(action) {
 }
 
 function* editShipment(action) {
-  const { payload, history, redirectTo } = action;
+  const {
+    payload, history, redirectTo, gateway,
+  } = action;
   try {
     const data = yield call(
       httpService.makeRequest,
@@ -197,6 +200,15 @@ function* editShipment(action) {
       `${window.env.API_URL}${shipmentApiEndPoint}shipment/${payload.id}/`,
       payload,
     );
+    if (payload.gateway_ids.length > 0 && gateway) {
+      yield [
+        yield put(
+          editGateway(
+            gateway,
+          ),
+        ),
+      ];
+    }
     yield [
       yield put(
         getShipmentDetails(


### PR DESCRIPTION
## Purpose
_Integrate Zendesk widget_
_Update gateway when the shipment is canceled or completed_

## Further info
_Since the entire backend configuration to get updated status of Tive gateway is causing timeout issues. This PR is introduced as a workaround to trigger gateway status update from FE instead of sensor service_

## Ticket number
_#289_
_#290_
