### PR TITLE
Add functionality to remove custodian from a shipment

### DIFF
--- a/src/pages/Shipment/components/custodian-info/CustodianInfo.js
+++ b/src/pages/Shipment/components/custodian-info/CustodianInfo.js
@@ -14,6 +14,9 @@ import {
   getFormattedCustodyRows,
   custodyColumns,
 } from '../../ShipmentConstants';
+import {
+  deleteCustody,
+} from '@redux/custodian/actions/custodian.actions';
 
 const useStyles = makeStyles((theme) => ({
   buttonContainer: {
@@ -34,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
 
 const CustodianInfo = (props) => {
   const {
+    dispatch,
     custodianData,
     handleNext,
     handleCancel,
@@ -51,6 +55,8 @@ const CustodianInfo = (props) => {
   const [openConfirmModal, setConfirmModal] = useState(false);
   const [rows, setRows] = useState([]);
   const [editItem, setEditItem] = useState(null);
+  const [openDeleteModal, setDeleteModal] = useState(false);
+  const [deleteItem, setDeleteItem] = useState(null);
 
   useEffect(() => {
     if (
@@ -91,6 +97,16 @@ const CustodianInfo = (props) => {
     setFormModal(true);
   };
 
+  const deleteCustodyItem = (item) => {
+    setDeleteItem(item.id);
+    setDeleteModal(true);
+  };
+
+  const handleDeleteModal = () => {
+    dispatch(deleteCustody(deleteItem, shipmentFormData.id, shipmentFormData.organization_uuid));
+    setDeleteModal(false);
+  };
+
   return (
     <Box mb={5} mt={3}>
       <Button
@@ -116,6 +132,11 @@ const CustodianInfo = (props) => {
                 rows={rows}
                 columns={custodyColumns(timezone)}
                 editAction={editCustody}
+                deleteAction={deleteCustodyItem}
+                openDeleteModal={openDeleteModal}
+                setDeleteModal={setDeleteModal}
+                handleDeleteModal={handleDeleteModal}
+                deleteModalTitle="Are you sure you want to Delete this Custody?"
                 hideAddButton
                 noOptionsIcon
                 noSpace

--- a/src/redux/custodian/actions/custodian.actions.js
+++ b/src/redux/custodian/actions/custodian.actions.js
@@ -35,6 +35,10 @@ export const UPDATE_CUSTODY = 'CUSTODIAN/UPDATE_CUSTODY';
 export const UPDATE_CUSTODY_SUCCESS = 'CUSTODIAN/UPDATE_CUSTODY_SUCCESS';
 export const UPDATE_CUSTODY_FAILURE = 'CUSTODIAN/UPDATE_CUSTODY_FAILURE';
 
+export const DELETE_CUSTODY = 'CUSTODIAN/DELETE_CUSTODY';
+export const DELETE_CUSTODY_SUCCESS = 'CUSTODIAN/DELETE_CUSTODY_SUCCESS';
+export const DELETE_CUSTODY_FAILURE = 'CUSTODIAN/DELETE_CUSTODY_FAILURE';
+
 export const GET_CUSTODIAN_TYPE = 'CUSTODIAN/GET_CUSTODIAN_TYPE';
 export const GET_CUSTODIAN_TYPE_SUCCESS = 'CUSTODIAN/GET_CUSTODIAN_TYPE_SUCCESS';
 export const GET_CUSTODIAN_TYPE_FAILURE = 'CUSTODIAN/GET_CUSTODIAN_TYPE_FAILURE';
@@ -149,6 +153,23 @@ export const editCustody = (payload) => ({
 export const updateCustody = (payload) => ({
   type: UPDATE_CUSTODY,
   payload,
+});
+
+/**
+ * Delete Custody
+ * @param {Number} custodyId
+ * @param {String} shipmentId
+ * @param {String} organization_uuid
+ */
+export const deleteCustody = (
+  custodyId,
+  shipmentId,
+  organization_uuid,
+) => ({
+  type: DELETE_CUSTODY,
+  custodyId,
+  shipmentId,
+  organization_uuid,
 });
 
 /**

--- a/src/redux/custodian/reducers/custodian.reducer.js
+++ b/src/redux/custodian/reducers/custodian.reducer.js
@@ -27,6 +27,9 @@ import {
   UPDATE_CUSTODY,
   UPDATE_CUSTODY_SUCCESS,
   UPDATE_CUSTODY_FAILURE,
+  DELETE_CUSTODY,
+  DELETE_CUSTODY_SUCCESS,
+  DELETE_CUSTODY_FAILURE,
   GET_CUSTODIAN_TYPE,
   GET_CUSTODIAN_TYPE_SUCCESS,
   GET_CUSTODIAN_TYPE_FAILURE,
@@ -277,6 +280,30 @@ export default (state = initialState, action) => {
       };
 
     case UPDATE_CUSTODY_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        error: action.error,
+      };
+
+    case DELETE_CUSTODY:
+      return {
+        ...state,
+        loading: true,
+        loaded: false,
+        error: null,
+      };
+
+    case DELETE_CUSTODY_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        custodyData: action.data,
+      };
+
+    case DELETE_CUSTODY_FAILURE:
       return {
         ...state,
         loading: false,

--- a/src/redux/custodian/sagas/custodian.saga.js
+++ b/src/redux/custodian/sagas/custodian.saga.js
@@ -27,6 +27,8 @@ import {
   EDIT_CUSTODY_FAILURE,
   UPDATE_CUSTODY,
   UPDATE_CUSTODY_FAILURE,
+  DELETE_CUSTODY,
+  DELETE_CUSTODY_FAILURE,
   GET_CUSTODIAN_TYPE,
   GET_CUSTODIAN_TYPE_SUCCESS,
   GET_CUSTODIAN_TYPE_FAILURE,
@@ -444,6 +446,50 @@ function* updateCustody(action) {
   }
 }
 
+function* deleteCustody(payload) {
+  const { custodyId, shipmentId, organization_uuid } = payload;
+  try {
+    yield call(
+      httpService.makeRequest,
+      'delete',
+      `${window.env.API_URL}${custodiansApiEndPoint}custody/${custodyId}/`,
+    );
+    yield [
+      yield put(
+        showAlert({
+          type: 'success',
+          open: true,
+          message: 'Custody deleted successfully!',
+        }),
+      ),
+      yield put(
+        getShipmentDetails(
+          organization_uuid,
+          null,
+          shipmentId,
+          false,
+          true,
+          'get',
+        ),
+      ),
+    ];
+  } catch (error) {
+    yield [
+      yield put(
+        showAlert({
+          type: 'error',
+          open: true,
+          message: 'Error in deleting Custody!',
+        }),
+      ),
+      yield put({
+        type: DELETE_CUSTODY_FAILURE,
+        error,
+      }),
+    ];
+  }
+}
+
 function* getCustodianType() {
   try {
     const data = yield call(
@@ -650,6 +696,10 @@ function* watchUpdateCustody() {
   yield takeLatest(UPDATE_CUSTODY, updateCustody);
 }
 
+function* watchDeleteCustody() {
+  yield takeLatest(DELETE_CUSTODY, deleteCustody);
+}
+
 function* watchGetCustodianType() {
   yield takeLatest(GET_CUSTODIAN_TYPE, getCustodianType);
 }
@@ -681,6 +731,7 @@ export default function* custodianSaga() {
     watchAddCustody(),
     watchEditCustody(),
     watchUpdateCustody(),
+    watchDeleteCustody(),
     watchGetCustodianType(),
     watchAddCustodianType(),
     watchEditCustodianType(),


### PR DESCRIPTION
## Purpose
_Unlink custodian from a shipment_

## Further info
_When adding a Custodian to a Shipment, the user would like to be able to remove a Custodian from a specific shipment, especially if there is a mistake made or a change in Custodian when the Shipment is still in Planned Status._

## Ticket number
_#299_
